### PR TITLE
fix(nfc): unify cancel button behavior across all association dialog states

### DIFF
--- a/front/src/components/files/NfcAssociateDialog.vue
+++ b/front/src/components/files/NfcAssociateDialog.vue
@@ -59,7 +59,7 @@
             <p><strong>{{ $t('nfc.associate.existingPlaylist') }}:</strong> {{ existingPlaylistInfo.title }}</p>
           </div>
           <div class="button-group">
-            <button class="btn btn-secondary" @click="handleClose">
+            <button class="btn btn-secondary" @click="cancelAssociation">
               {{ $t('common.cancel') }}
             </button>
             <button class="btn btn-warning" @click="replaceAssociation">
@@ -75,7 +75,7 @@
           </div>
           <p>{{ message || $t('nfc.associate.error') }}</p>
           <div class="button-group">
-            <button class="btn btn-secondary" @click="handleClose">
+            <button class="btn btn-secondary" @click="cancelAssociation">
               {{ $t('common.close') }}
             </button>
             <button class="btn btn-primary" @click="retryAssociation">
@@ -102,7 +102,7 @@
           </div>
           <p>{{ $t('nfc.associate.timedOut') }}</p>
           <div class="button-group">
-            <button class="btn btn-secondary" @click="handleClose">
+            <button class="btn btn-secondary" @click="cancelAssociation">
               {{ $t('common.close') }}
             </button>
             <button class="btn btn-primary" @click="retryAssociation">
@@ -342,6 +342,11 @@ async function cancelAssociation() {
   stopCountdown()
   stopAssociationPolling()
   state.value = 'cancelled'
+
+  // Auto-close dialog after showing cancelled state briefly
+  setTimeout(() => {
+    handleClose()
+  }, 1500)
 }
 
 function retryAssociation() {
@@ -370,7 +375,8 @@ function handleBackdropClick() {
 async function handleClose() {
   console.log('🚪 handleClose() called, state:', state.value, 'session_id:', currentSessionId.value)
 
-  // Stop any ongoing association
+  // Stop any ongoing association if user closes with X button while waiting
+  // (cancelAssociation() handles this for Cancel buttons)
   if (state.value === 'waiting' && currentSessionId.value) {
     try {
       console.log('🔄 Cancelling association on close with session_id:', currentSessionId.value)


### PR DESCRIPTION
## Summary
Fixes inconsistent cancel button behavior in the NFC association dialog. Now all Cancel buttons properly exit association mode and cancel the backend session.

## Problem
When scanning an already-associated NFC tag during association mode:
1. ✅ LED blinks orange (warning indicator) - worked correctly
2. ✅ Dialog shows duplicate warning - worked correctly
3. ❌ **BUG**: Clicking Cancel didn't exit association mode:
   - LED returned to blue pulse (association mode still active)
   - Backend session remained active
   - User couldn't properly exit association mode

This was inconsistent with the Cancel button in the "waiting" state, which properly cancelled the backend session.

## Root Cause
Different dialog states used different cancel mechanisms in `NfcAssociateDialog.vue`:

| State | Line | Cancel Handler | Backend Cancelled? |
|-------|------|---------------|-------------------|
| `waiting` | 36-38 | `cancelAssociation()` | ✅ Yes |
| `already_associated` | 62-64 | `handleClose()` | ❌ **No** |
| `error` | 78-80 | `handleClose()` | ❌ No |
| `timeout` | 105-107 | `handleClose()` | ❌ No |

`handleClose()` only cancelled the backend session when `state === 'waiting'`, leaving sessions active for all other states.

## Solution
Unified cancel button behavior across all states:

### 1. Updated `cancelAssociation()` (line 326-350)
- Added auto-close after 1.5s to show "cancelled" feedback
- Single source of truth for cancellation logic
- Consistently: cancels backend session → stops timers → shows feedback → closes dialog

### 2. Updated all Cancel buttons to use `cancelAssociation()`
- `already_associated` state (line 62): `handleClose` → `cancelAssociation`
- `error/hardware_error` states (line 78): `handleClose` → `cancelAssociation`
- `timeout` state (line 105): `handleClose` → `cancelAssociation`

### 3. Updated `handleClose()` documentation (line 378-379)
- Clarified it only handles X button close for waiting state
- All Cancel buttons now go through `cancelAssociation()`

## Code Changes
```diff
async function cancelAssociation() {
  // ... existing cancellation logic ...
  state.value = 'cancelled'
+
+  // Auto-close dialog after showing cancelled state briefly
+  setTimeout(() => {
+    handleClose()
+  }, 1500)
}
```

```diff
<!-- Already Associated State -->
- <button class="btn btn-secondary" @click="handleClose">
+ <button class="btn btn-secondary" @click="cancelAssociation">
    {{ $t('common.cancel') }}
  </button>
```

(Similar changes for error and timeout states)

## Benefits
✅ Consistent user experience across all dialog states
✅ Single source of truth for cancellation logic
✅ Backend session always properly cancelled when user clicks Cancel
✅ LED properly returns to IDLE state (white solid)
✅ Clear separation of concerns:
  - `cancelAssociation()` = cancel backend + close dialog
  - `handleClose()` = just close dialog

## Testing
- ✅ All frontend tests pass: **785 passed, 1 skipped**
- ✅ No new test failures introduced
- ✅ Consistent behavior across all cancel scenarios

## User Experience After Fix
```
User scans already-associated tag during association mode
  ↓
Orange blink (warning)
  ↓
Dialog shows duplicate warning with Cancel/Replace buttons
  ↓
User clicks Cancel
  ↓
Backend session cancelled (DELETE /api/nfc/session/{id})
  ↓
Dialog shows "Cancelled" message (1.5s)
  ↓
Dialog auto-closes
  ↓
LED returns to appropriate state:
  - Music playing → Green solid (PLAYING)
  - Nothing playing → White solid (IDLE)
```

## Manual Testing Checklist
- [ ] Start NFC association for Playlist A
- [ ] Scan tag already associated with Playlist B
- [ ] Verify orange blink (warning)
- [ ] Click Cancel button
- [ ] Verify "Cancelled" message shows briefly
- [ ] Verify dialog auto-closes after 1.5s
- [ ] Verify LED returns to IDLE state (white solid)
- [ ] Verify backend session is terminated
- [ ] Verify can start new association immediately
- [ ] Test same flow with error states (timeout, hardware error)

## Related
- Closes #9
- Follow-up to commit 59423f51d which fixed LED state after cancellation but didn't address cancel button inconsistency
- Part of feat/rgb-led-indicator merge (commit 8eb1f895)

---

**Component**: `front/src/components/files/NfcAssociateDialog.vue`
**Lines Changed**: +10 -4
**Risk Level**: Low (only changes button event handlers, maintains existing functionality)
**Breaking Changes**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)