### PR TITLE
chore(ci): make Pushgateway export conditional

### DIFF
--- a/.github/workflows/code-quality-metrics.yml
+++ b/.github/workflows/code-quality-metrics.yml
@@ -47,9 +47,15 @@ jobs:
 
       - name: Run metrics collection
         run: |
-          ./scripts/export_metrics.sh http://host.docker.internal:9091
+          # Export metrics to Pushgateway if available (local CI only)
+          if [ -n "$PUSHGATEWAY_URL" ]; then
+            ./scripts/export_metrics.sh "$PUSHGATEWAY_URL"
+          else
+            echo "Skipping Pushgateway export (PUSHGATEWAY_URL not set)"
+          fi
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
+          PUSHGATEWAY_URL: ${{ vars.PUSHGATEWAY_URL }}
 
       - name: Generate metrics summary
         if: always()
@@ -76,4 +82,4 @@ jobs:
           echo "| Docstring Coverage | $DOCSTRING |" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "View detailed dashboard at: http://homesrv.local:3001" >> $GITHUB_STEP_SUMMARY
+          echo "View detailed dashboard at: ${{ vars.DASHBOARD_URL || 'N/A' }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Make Pushgateway metrics export conditional so workflows work on both local Docker (Act) and GitHub Actions.

## Changes

- Use `PUSHGATEWAY_URL` repository variable instead of hardcoded `host.docker.internal:9091`
- Use `DASHBOARD_URL` variable for Grafana dashboard link
- Skip metrics export when variables are not set

## Test plan

- [x] Workflow YAML syntax validated
- [ ] Works on GitHub Actions (variables not set = skip export)
- [ ] Works on local Act (variables can be set)