### PR TITLE
fix(ci): Use pre-installed Python on self-hosted runner

### DIFF
--- a/.github/workflows/code-quality-metrics.yml
+++ b/.github/workflows/code-quality-metrics.yml
@@ -28,15 +28,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      # Python 3.13 is pre-installed on self-hosted runner
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11'
+      #     cache: 'pip'
+
+      - name: Set up Python virtual environment
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          echo "VIRTUAL_ENV=$PWD/venv" >> $GITHUB_ENV
+          echo "$PWD/venv/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          source venv/bin/activate
           pip install -r requirements.txt
           pip install -r requirements-test.txt
 
@@ -47,6 +56,7 @@ jobs:
 
       - name: Run metrics collection
         run: |
+          source venv/bin/activate
           # Export metrics to Pushgateway if available (local CI only)
           if [ -n "$PUSHGATEWAY_URL" ]; then
             ./scripts/export_metrics.sh "$PUSHGATEWAY_URL"
@@ -60,6 +70,7 @@ jobs:
       - name: Generate metrics summary
         if: always()
         run: |
+          source venv/bin/activate
           echo "## Code Quality Metrics Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Fix CI failure on self-hosted ARM64 Debian 13 runner where Python 3.11 is not available
- Use pre-installed Python 3.13 with manual venv setup (same pattern as contract-validation.yml)
- All open PRs (#51, #54, #59, #60, #61, #62) are affected by this issue

## Root Cause

The `code-quality-metrics.yml` workflow was using `actions/setup-python@v5` with Python 3.11, which fails on the self-hosted runner with:
```
The version '3.11' with architecture 'arm64' was not found for Debian 13.
```

## Changes

- Comment out `actions/setup-python@v5` step
- Add `Set up Python virtual environment` step using pre-installed Python 3.13
- Source venv in all steps that use Python commands

## Test plan

- [ ] Verify "Collect Code Quality Metrics" job passes after merge
- [ ] Re-run CI on affected PRs to confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)