### PR TITLE
fix(ci): Update workflow runner labels for Docker self-hosted runner

### DIFF
--- a/.github/workflows/code-quality-metrics.yml
+++ b/.github/workflows/code-quality-metrics.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   collect-metrics:
     name: Collect Code Quality Metrics
-    runs-on: self-hosted
+    runs-on: [self-hosted, docker]
 
     defaults:
       run:

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   contract-validation:
     name: API & Socket.IO Contract Validation
-    runs-on: [self-hosted, Linux, ARM64, rpi]
+    runs-on: [self-hosted, Linux, X64, docker]
 
     steps:
     - name: Checkout repository
@@ -327,7 +327,7 @@ jobs:
   # Separate job for contract drift detection (only on schedule)
   contract-drift-detection:
     name: Contract Drift Detection
-    runs-on: [self-hosted, Linux, ARM64, rpi]
+    runs-on: [self-hosted, Linux, X64, docker]
     if: github.event_name == 'schedule'
 
     steps:


### PR DESCRIPTION
## Summary

- Replace ARM64/rpi labels with X64/docker labels for self-hosted runner
- Runner is now `mac-docker-runner` running locally in Docker
- Removed dependency on `rpi-homesrv` runner

## Changes

- `contract-validation.yml`: `[self-hosted, Linux, ARM64, rpi]` → `[self-hosted, Linux, X64, docker]`
- `code-quality-metrics.yml`: `self-hosted` → `[self-hosted, docker]`

## Test plan

- [ ] CI workflows run successfully on the new Docker runner
- [ ] PR status checks appear on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)