### PR TITLE
test(volume): Update volume control tests to expect 10% increments

### DIFF
--- a/back/tests/unit/application/controllers/test_physical_controls_controller.py
+++ b/back/tests/unit/application/controllers/test_physical_controls_controller.py
@@ -270,7 +270,7 @@ class TestVolumeHandling:
         # Give async task time to execute
         await asyncio.sleep(0.01)
 
-        coordinator.set_volume.assert_called_with(55)  # +5%
+        coordinator.set_volume.assert_called_with(60)  # +10% (default volume_step from config)
 
     @pytest.mark.asyncio
     async def test_handle_volume_down_with_coordinator(self):
@@ -289,7 +289,7 @@ class TestVolumeHandling:
 
         await asyncio.sleep(0.01)
 
-        coordinator.set_volume.assert_called_with(45)  # -5%
+        coordinator.set_volume.assert_called_with(40)  # -10% (default volume_step from config)
 
     @pytest.mark.asyncio
     async def test_volume_up_max_limit(self):


### PR DESCRIPTION
## Summary

Fixes issue #76 where two volume control tests were failing because they expected +5% increments but the actual implementation uses +10% increments.

## Problem

Two tests in `test_physical_controls_controller.py` were failing:
1. `test_handle_volume_up_with_coordinator` - Expected +5% but got +10%
2. `test_handle_volume_down_with_coordinator` - Expected -5% but got -10%

The tests were outdated after PR #72 changed the volume step from 5% to 10% to match the configured `audio_config.volume_step = 10`.

## Root Cause

PR #72 fixed the volume control implementation to use `config.audio.volume_step` (which defaults to 10%) instead of the hardcoded 5% value. However, the unit tests were not updated to reflect this change.

## Changes Made

Updated test expectations in `back/tests/unit/application/controllers/test_physical_controls_controller.py`:
- Line 273: Changed expected volume from 55 to 60 for volume up (+10% from 50%)
- Line 292: Changed expected volume from 45 to 40 for volume down (-10% from 50%)
- Added clarifying comments explaining the 10% default from config

## Testing

- Unit tests now pass with the updated expectations
- Behavior matches the implementation from PR #72
- Volume control works as expected with rotary encoder (10% per detent)

## Related

- Fixes #76
- Related to PR #72 (which introduced the 10% volume step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>