### PR TITLE
fix(nfc): resolve duplicate NFC session blocking issue

### DIFF
--- a/back/app/src/api/endpoints/nfc_api_routes.py
+++ b/back/app/src/api/endpoints/nfc_api_routes.py
@@ -616,6 +616,110 @@ class NFCAPIRoutes:
                     client_op_id=body.client_op_id
                 )
 
+        @self.router.get("/sessions")
+        @handle_http_errors()
+        async def get_all_sessions(request: Request):
+            """Get all NFC association sessions (active and inactive).
+
+            Returns a list of all sessions with their current state, allowing
+            monitoring and debugging of the association system.
+            """
+            try:
+                # Get services
+                nfc_service, _, error_response = await self._get_services_or_error(request)
+                if error_response:
+                    return error_response
+
+                # Get all sessions
+                result = await nfc_service.get_all_sessions_use_case()
+
+                logger.info(f"Retrieved {result.get('count', 0)} NFC association sessions")
+                return UnifiedResponseService.success(
+                    message="Sessions retrieved successfully",
+                    data={
+                        "sessions": result.get("sessions", []),
+                        "count": result.get("count", 0)
+                    }
+                )
+
+            except Exception as e:
+                logger.error(
+                    f"Error in get_all_sessions: {e!s}",
+                    extra={
+                        "request_id": request.headers.get("X-Request-ID") if request else None,
+                        "operation": "get_all_sessions",
+                    },
+                    exc_info=True
+                )
+                return UnifiedResponseService.internal_error(
+                    message="Failed to retrieve NFC sessions",
+                    operation="get_all_sessions"
+                )
+
+        @self.router.post("/sessions/cleanup")
+        @handle_http_errors()
+        async def cleanup_sessions(
+            request: Request,
+            body: ClientOperationRequest = ClientOperationRequest(),
+        ):
+            """Clean up NFC association sessions in terminal states.
+
+            This endpoint removes sessions in DUPLICATE, TIMEOUT, ERROR, STOPPED,
+            CANCELLED, and SUCCESS states. Useful for recovering from stuck sessions
+            without requiring a service restart.
+
+            Query parameters:
+            - force_all: If true, removes ALL sessions regardless of state
+            """
+            try:
+                client_op_id = body.client_op_id
+                force_all = request.query_params.get("force_all", "false").lower() == "true"
+
+                # Get services
+                nfc_service, state_manager, error_response = await self._get_services_or_error(
+                    request, client_op_id
+                )
+                if error_response:
+                    return error_response
+
+                logger.info(f"🧹 Cleaning up NFC sessions (force_all={force_all})")
+
+                # Cleanup terminal sessions
+                result = await nfc_service.cleanup_terminal_sessions_use_case(force_all=force_all)
+
+                cleaned_count = result.get("cleaned_count", 0)
+                logger.info(f"✅ Cleaned up {cleaned_count} NFC session(s)")
+
+                # Send acknowledgment
+                if state_manager and client_op_id:
+                    await state_manager.send_acknowledgment(
+                        client_op_id,
+                        True,
+                        {"cleaned_count": cleaned_count}
+                    )
+
+                return UnifiedResponseService.success(
+                    message=result.get("message", "Sessions cleaned up"),
+                    data={"cleaned_count": cleaned_count},
+                    client_op_id=client_op_id
+                )
+
+            except Exception as e:
+                logger.error(
+                    f"Error in cleanup_sessions: {e!s}",
+                    extra={
+                        "client_op_id": body.client_op_id if hasattr(body, 'client_op_id') else None,
+                        "request_id": request.headers.get("X-Request-ID") if request else None,
+                        "operation": "cleanup_sessions",
+                    },
+                    exc_info=True
+                )
+                return UnifiedResponseService.internal_error(
+                    message="Failed to cleanup NFC sessions",
+                    operation="cleanup_sessions",
+                    client_op_id=body.client_op_id
+                )
+
     def get_router(self) -> APIRouter:
         """Get the configured router."""
         return self.router

--- a/back/app/src/application/services/nfc_application_service.py
+++ b/back/app/src/application/services/nfc_application_service.py
@@ -501,6 +501,46 @@ class NfcApplicationService:
         for callback in self._tag_detected_callbacks:
             callback(str(tag_identifier))
 
+    async def get_all_sessions_use_case(self) -> dict[str, Any]:
+        """Use case: Get all association sessions (active and inactive).
+
+        Returns:
+            Result dictionary with all sessions
+        """
+        all_sessions = self._association_service.get_all_sessions()
+        return {
+            "status": "success",
+            "sessions": [session.to_dict() for session in all_sessions],
+            "count": len(all_sessions),
+        }
+
+    async def cleanup_terminal_sessions_use_case(self, force_all: bool = False) -> dict[str, Any]:
+        """Use case: Clean up sessions in terminal states.
+
+        Args:
+            force_all: If True, remove ALL sessions regardless of state
+
+        Returns:
+            Result dictionary with cleanup count
+        """
+        cleaned_count = await self._association_service.cleanup_terminal_sessions(force_all)
+
+        # Clear association mode LED if no more active sessions
+        if cleaned_count > 0:
+            active_sessions = self._association_service.get_active_sessions()
+            if len(active_sessions) == 0 and self._led_event_handler:
+                try:
+                    await self._led_event_handler.clear_led_state(LEDState.NFC_ASSOCIATION_MODE)
+                    logger.info("💡 No more active sessions after cleanup, cleared blue pulse LED")
+                except Exception as led_error:
+                    logger.warning(f"LED event failed (non-critical): {led_error}")
+
+        return {
+            "status": "success",
+            "cleaned_count": cleaned_count,
+            "message": f"Cleaned up {cleaned_count} session(s)",
+        }
+
     async def _periodic_cleanup(self) -> None:
         """Periodic cleanup of expired sessions."""
         while True:

--- a/back/app/src/domain/nfc/services/nfc_association_service.py
+++ b/back/app/src/domain/nfc/services/nfc_association_service.py
@@ -204,6 +204,12 @@ class NfcAssociationService:
                     logger.warning(
                         f"🔄 Tag {tag.identifier} already associated with playlist {existing_playlist_id} (same={is_same_playlist})"
                     )
+
+                    # Schedule auto-cleanup of duplicate session after 5 seconds
+                    # This prevents the session from blocking future association attempts
+                    import asyncio
+                    asyncio.create_task(self._cleanup_duplicate_session(session.session_id, delay=5.0))
+                    logger.info(f"⏱️ Scheduled auto-cleanup for duplicate session {session.session_id} in 5 seconds")
                 else:
                     logger.debug(
                         f"🔄 Tag {tag.identifier} re-detected, session already in {session.state} state"
@@ -372,3 +378,84 @@ class NfcAssociationService:
             logger.debug(f"Session {session_id} not cleaned up - state: {session.state}")
         else:
             logger.debug(f"Session {session_id} not found for cleanup")
+
+    async def _cleanup_duplicate_session(self, session_id: str, delay: float = 5.0) -> None:
+        """Clean up a duplicate association session after a delay.
+
+        This prevents duplicate sessions from blocking future association attempts.
+
+        Args:
+            session_id: ID of session to clean up
+            delay: Delay in seconds before cleanup (default: 5.0)
+        """
+        import asyncio
+
+        # Wait for specified delay to allow user to see duplicate state
+        await asyncio.sleep(delay)
+
+        session = self._active_sessions.get(session_id)
+        if session and session.state == SessionState.DUPLICATE:
+            # Remove from active sessions
+            del self._active_sessions[session_id]
+            logger.info(f"🧹 Auto-cleaned up duplicate association session {session_id} after {delay}s")
+        elif session:
+            logger.debug(f"Session {session_id} not cleaned up - state changed to: {session.state}")
+        else:
+            logger.debug(f"Session {session_id} already removed")
+
+    async def cleanup_terminal_sessions(self, force_all: bool = False) -> int:
+        """Clean up sessions in terminal states (DUPLICATE, TIMEOUT, ERROR, STOPPED, CANCELLED).
+
+        Args:
+            force_all: If True, remove ALL sessions regardless of state
+
+        Returns:
+            Number of sessions cleaned up
+        """
+        terminal_states = [
+            SessionState.DUPLICATE,
+            SessionState.TIMEOUT,
+            SessionState.ERROR,
+            SessionState.STOPPED,
+            SessionState.CANCELLED,
+            SessionState.SUCCESS,
+        ]
+
+        cleaned_count = 0
+        sessions_to_remove = []
+
+        for session_id, session in self._active_sessions.items():
+            should_remove = False
+
+            if force_all:
+                should_remove = True
+            elif session.state in terminal_states:
+                should_remove = True
+            elif session.is_expired():
+                should_remove = True
+
+            if should_remove:
+                sessions_to_remove.append(session_id)
+                logger.info(
+                    f"🧹 Cleaning up session {session_id} (state={session.state.value}, expired={session.is_expired()})"
+                )
+
+        # Remove sessions
+        for session_id in sessions_to_remove:
+            del self._active_sessions[session_id]
+            cleaned_count += 1
+
+        if cleaned_count > 0:
+            logger.info(f"🧹 Cleaned up {cleaned_count} terminal session(s)")
+        else:
+            logger.debug("No terminal sessions to clean up")
+
+        return cleaned_count
+
+    def get_all_sessions(self) -> list[AssociationSession]:
+        """Get all association sessions (active and inactive).
+
+        Returns:
+            List of all sessions
+        """
+        return list(self._active_sessions.values())


### PR DESCRIPTION
## Summary
Fixes NFC association sessions getting stuck in DUPLICATE state and blocking future association attempts indefinitely.

## Problem
When an NFC tag that is already associated with a playlist is detected during an association session:
1. The session enters `DUPLICATE` state
2. The session remains in `_active_sessions` dict
3. `is_active()` returns `True` for `DUPLICATE` state
4. The session blocks new association attempts until service restart

## Solution

### 1. Automatic Cleanup (Primary Fix)
- Schedules auto-cleanup task when session enters DUPLICATE state
- Removes session after 5-second delay (allows UI to show duplicate error)
- Prevents indefinite blocking without user intervention

### 2. Manual Management Endpoints
- `GET /api/nfc/sessions`: List all sessions with state details
- `POST /api/nfc/sessions/cleanup`: Clean up terminal state sessions
  - Removes sessions in DUPLICATE, TIMEOUT, ERROR, STOPPED, CANCELLED, SUCCESS states
  - Supports `force_all` query parameter to remove all sessions
- Provides manual recovery option without service restart

### 3. Service Layer Methods
- `cleanup_terminal_sessions()`: Clean up all terminal state sessions
- `get_all_sessions()`: Retrieve all sessions for monitoring

## Changes
- `nfc_association_service.py`: 
  - Auto-cleanup on duplicate detection
  - Terminal session cleanup method
  - Session listing method
- `nfc_application_service.py`:
  - Expose cleanup/listing through use cases
  - Auto-clear LED state when sessions cleaned
- `nfc_api_routes.py`:
  - New session management endpoints

## Test plan
- [x] Business logic tests pass
- [x] Rebased on develop
- [x] Auto-cleanup prevents session blocking
- [ ] Manual cleanup endpoint tested
- [ ] Session listing endpoint tested

## Impact
- **Severity**: Medium → Low (auto-cleanup prevents blocking)
- **User Experience**: No more service restarts required
- **Backwards Compatible**: Yes, only adds new functionality

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)