### PR TITLE
fix(issue-98): normalize track_number to number in serialize_track dict handling

### DIFF
--- a/back/app/src/services/serialization/unified_serialization_service.py
+++ b/back/app/src/services/serialization/unified_serialization_service.py
@@ -174,7 +174,11 @@ class UnifiedSerializationService:
         """
         # Handle different input types
         if isinstance(track, dict):
-            track_data = track
+            # Normalize dict to use 'number' field (OpenAPI contract)
+            # Support both 'track_number' (legacy) and 'number' (current)
+            track_data = track.copy()
+            if "track_number" in track_data and "number" not in track_data:
+                track_data["number"] = track_data["track_number"]
         elif hasattr(track, "__dict__"):
             # Domain entity
             track_data = {


### PR DESCRIPTION
## Summary
Fixes failing tests by normalizing legacy `track_number` field to `number` when processing dict inputs in `UnifiedSerializationService.serialize_track()`.

## Problem
Two tests were failing:
- `tests/unit/services/test_unified_serialization_service.py::TestTrackSerialization::test_serialize_track_from_dict`
- `tests/unit/test_serialization_contracts.py::TestSerializationContracts::test_track_serialization_from_dict`

**Root cause:** Incomplete migration from `track_number` to `number` field (OpenAPI contract v3.3.2).

When `serialize_track()` receives a dict with `track_number`, it wasn't being normalized to `number`, causing serialized output to have `number: 0` instead of the expected value.

## Solution
Added normalization logic in dict handling path:
```python
if isinstance(track, dict):
    # Normalize dict to use 'number' field (OpenAPI contract)
    # Support both 'track_number' (legacy) and 'number' (current)
    track_data = track.copy()
    if "track_number" in track_data and "number" not in track_data:
        track_data["number"] = track_data["track_number"]
```

## Changes
- **back/app/src/services/serialization/unified_serialization_service.py**
  - Added dict normalization to convert `track_number` → `number`
  - Maintains backwards compatibility with legacy field names
  - Respects OpenAPI contract v3.3.2 requirements

## Testing
```bash
./deploy.sh --test-only
```

✅ All tests pass (2218 passed, 13 skipped)
✅ Both previously failing tests now pass
✅ No regressions introduced

## Impact
- ✅ Fixes 2 failing tests
- ✅ Maintains backwards compatibility
- ✅ Aligns with OpenAPI contract v3.3.2

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>