### PR TITLE
fix(ci): Rename ci_build_success to ci_tests_success for Grafana

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,7 @@ EOF
 
                     sh """
                         cat <<EOF | curl --data-binary @- ${PUSHGATEWAY_URL}/metrics/job/ci/instance/${REPO_NAME} || true
-ci_build_success{repo="${REPO_NAME}",branch="${branchName}"} ${buildSuccess}
+ci_tests_success{repo="${REPO_NAME}",branch="${branchName}"} ${buildSuccess}
 ci_build_duration_seconds{repo="${REPO_NAME}",branch="${branchName}"} ${buildDuration}
 ci_build_timestamp{repo="${REPO_NAME}",branch="${branchName}"} \$(date +%s)
 EOF


### PR DESCRIPTION
## Summary

- Renames `ci_build_success` metric to `ci_tests_success` in Jenkinsfile
- Aligns with Grafana dashboard expectations
- Consistent with related metrics naming (`ci_tests_total`, `ci_tests_passed`)

## Test plan

- [ ] Verify Jenkins build completes successfully
- [ ] Check metrics appear in Pushgateway with new name
- [ ] Confirm Grafana dashboard displays data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)