### PR TITLE
fix(contracts): migrate Track.number to Track.track_number for OpenAPI v4.1.0

### DIFF
--- a/back/app/src/api/endpoints/playlist/playlist_track_api.py
+++ b/back/app/src/api/endpoints/playlist/playlist_track_api.py
@@ -148,7 +148,8 @@ class PlaylistTrackAPI(BaseAPIRoutes):
             try:
                 source_playlist_id = body.get("source_playlist_id")
                 target_playlist_id = body.get("target_playlist_id")
-                track_number = body.get("number")
+                # OpenAPI v4.1.0 uses track_number, fallback to number for backward compat
+                track_number = body.get("track_number", body.get("number"))
                 target_position = body.get("target_position")
                 client_op_id = body.get("client_op_id")
 
@@ -186,5 +187,5 @@ class PlaylistTrackAPI(BaseAPIRoutes):
                     client_op_id=body.get("client_op_id") if isinstance(body, dict) else None,
                     source_playlist_id=body.get("source_playlist_id") if isinstance(body, dict) else None,
                     target_playlist_id=body.get("target_playlist_id") if isinstance(body, dict) else None,
-                    track_number=body.get("number") if isinstance(body, dict) else None
+                    track_number=body.get("track_number", body.get("number")) if isinstance(body, dict) else None
                 )

--- a/back/app/src/api/endpoints/playlist/playlist_upload_api.py
+++ b/back/app/src/api/endpoints/playlist/playlist_upload_api.py
@@ -157,7 +157,7 @@ class PlaylistUploadAPI(BaseAPIRoutes):
                         "artist": track_data.get("artist"),
                         "album": track_data.get("album"),
                         "file_size": track_data.get("file_size"),
-                        "number": track_data.get("number", 1),
+                        "track_number": track_data.get("track_number", track_data.get("number", 1)),
                     }
 
                     # Add track via application service

--- a/back/app/src/api/services/playlist_operations_service.py
+++ b/back/app/src/api/services/playlist_operations_service.py
@@ -140,10 +140,11 @@ class PlaylistOperationsService:
                 return {"status": "error", "message": "Playlist not found"}
 
             # Filter out tracks to delete and keep remaining ones
+            # Use track_number (OpenAPI v4.1.0) with fallback to number for backward compat
             remaining_tracks = [
                 track
                 for track in playlist.get("tracks", [])
-                if track.get("number") not in track_numbers
+                if track.get("track_number", track.get("number")) not in track_numbers
             ]
 
             # Replace tracks with remaining ones in database
@@ -338,8 +339,9 @@ class PlaylistOperationsService:
                 }
 
             # Check track numbering integrity
+            # Use track_number (OpenAPI v4.1.0) with fallback to number for backward compat
             tracks = playlist_data.get("tracks", [])
-            track_numbers = [track.get("number", 0) for track in tracks]
+            track_numbers = [track.get("track_number", track.get("number", 0)) for track in tracks]
             expected_numbers = list(range(1, len(tracks) + 1))
 
             if sorted(track_numbers) != expected_numbers:

--- a/back/app/src/api/services/playlist_operations_service.py
+++ b/back/app/src/api/services/playlist_operations_service.py
@@ -74,7 +74,7 @@ class PlaylistOperationsService:
             tracks = []
             for track_dict in playlist_dict.get("tracks", []):
                 track = Track(
-                    number=track_dict.get("number", 0),
+                    track_number=track_dict.get("track_number", track_dict.get("number", 0)),  # OpenAPI v4.1.0
                     title=track_dict.get("title", ""),
                     filename=track_dict.get("filename", ""),
                     file_path=track_dict.get("file_path", ""),

--- a/back/app/src/application/controllers/upload_controller.py
+++ b/back/app/src/application/controllers/upload_controller.py
@@ -216,7 +216,7 @@ class UploadController:
             duration_ms = metadata_dict.get("duration", 0)
 
             track_entry = {
-                "number": new_track_number,
+                "track_number": new_track_number,
                 "title": (metadata_override or {}).get("title")
                 or metadata_dict.get("title")
                 or Path(filename).stem,

--- a/back/app/src/application/services/audio_application_service.py
+++ b/back/app/src/application/services/audio_application_service.py
@@ -69,7 +69,7 @@ class AudioApplicationService:
             tracks = []
             for track_data in playlist_data["tracks"]:
                 track = Track(
-                    track_number=track_data.get("number", 1),
+                    track_number=track_data.get("track_number", track_data.get("number", 1)),
                     title=track_data.get("title", "Unknown"),
                     filename=track_data.get("filename", ""),
                     file_path=track_data.get("file_path", ""),

--- a/back/app/src/application/services/audio_application_service.py
+++ b/back/app/src/application/services/audio_application_service.py
@@ -69,7 +69,7 @@ class AudioApplicationService:
             tracks = []
             for track_data in playlist_data["tracks"]:
                 track = Track(
-                    number=track_data.get("number", 1),
+                    track_number=track_data.get("number", 1),
                     title=track_data.get("title", "Unknown"),
                     filename=track_data.get("filename", ""),
                     file_path=track_data.get("file_path", ""),

--- a/back/app/src/application/services/data_application_service.py
+++ b/back/app/src/application/services/data_application_service.py
@@ -312,7 +312,7 @@ class DataApplicationService:
                 tracks = await self._track_service.get_tracks(playlist_id)
                 track_to_delete = next(
                     (t for t in tracks if (hasattr(t, 'number') and t.number == track_number)
-                     or (isinstance(t, dict) and t.get('number') == track_number)),
+                     or (isinstance(t, dict) and t.get('track_number', t.get('number')) == track_number)),  # OpenAPI v4.1.0
                     None
                 )
 

--- a/back/app/src/application/services/state_serialization_application_service.py
+++ b/back/app/src/application/services/state_serialization_application_service.py
@@ -114,7 +114,7 @@ class StateSerializationApplicationService:
             }
         else:
             # Handle domain object
-            # OpenAPI contract uses 'number', not 'number'
+            # OpenAPI contract v4.1.0 uses 'track_number'
             return {
                 "id": track.id,
                 "title": track.title,
@@ -122,7 +122,7 @@ class StateSerializationApplicationService:
                 "duration_ms": int((track.duration or 0) * 1000),
                 "artist": getattr(track, "artist", None),
                 "album": getattr(track, "album", None),
-                "number": getattr(track, "number", None),  # Fixed: 'number' not 'number'
+                "track_number": getattr(track, "number", None),  # OpenAPI v4.1.0: 'track_number'
                 "play_count": getattr(track, "play_count", 0),
                 "created_at": getattr(track, "created_at", None),
                 "server_seq": self.sequences.get_current_global_seq(),

--- a/back/app/src/common/data_models.py
+++ b/back/app/src/common/data_models.py
@@ -91,7 +91,7 @@ class TrackModel(TimestampedModel):
     # Metadata fields
     artist: str | None = Field(None, description="Track artist")
     album: str | None = Field(None, description="Track album")
-    number: int | None = Field(None, description="Track number in playlist - per OpenAPI contract v3.3.2")
+    track_number: int | None = Field(None, description="Track number in playlist - per OpenAPI contract v4.1.0")
 
     # Statistics
     play_count: int = Field(0, description="Number of times played")

--- a/back/app/src/config/openapi_examples.py
+++ b/back/app/src/config/openapi_examples.py
@@ -150,7 +150,7 @@ PLAYLIST_DETAIL_EXAMPLE = {
                             "name": "Song 1.mp3",
                             "artist": "Artist 1",
                             "duration_ms": 240000,
-                            "number": 1,
+                            "track_number": 1,
                             "file_path": "/music/playlists/playlist_123/Song 1.mp3"
                         },
                         {
@@ -158,7 +158,7 @@ PLAYLIST_DETAIL_EXAMPLE = {
                             "name": "Song 2.mp3",
                             "artist": "Artist 2",
                             "duration_ms": 210000,
-                            "number": 2,
+                            "track_number": 2,
                             "file_path": "/music/playlists/playlist_123/Song 2.mp3"
                         }
                     ],

--- a/back/app/src/domain/data/events/playlist_events.py
+++ b/back/app/src/domain/data/events/playlist_events.py
@@ -39,8 +39,13 @@ class TrackAddedEvent:
     track_id: str
     playlist_id: str
     track_name: str
-    number: int  # Position in playlist - per OpenAPI contract v3.3.2
+    track_number: int  # Position in playlist - per OpenAPI contract v4.1.0
     added_at: datetime
+
+    @property
+    def number(self) -> int:
+        """Backward compatibility alias for track_number."""
+        return self.track_number
 
 
 @dataclass

--- a/back/app/src/domain/data/models/track.py
+++ b/back/app/src/domain/data/models/track.py
@@ -4,7 +4,7 @@
 
 """Track domain entity following Domain-Driven Design principles."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -16,7 +16,7 @@ class Track:
     and rules related to audio tracks.
 
     Attributes:
-        number: Position in the playlist (1-based) - per OpenAPI contract v3.3.2
+        track_number: Position in the playlist (1-based) - per OpenAPI contract v4.1.0
         title: Title of the track
         filename: Filename of the track
         file_path: String path to the track file - aligned with frontend
@@ -26,7 +26,7 @@ class Track:
         id: Optional unique identifier
     """
 
-    number: int  # Position in playlist - per OpenAPI contract v3.3.2
+    track_number: int  # Position in playlist - per OpenAPI contract v4.1.0
     title: str
     filename: str
     file_path: str  # Changed from Path to string to align with frontend
@@ -34,6 +34,16 @@ class Track:
     artist: str | None = None
     album: str | None = None
     id: str | None = None
+
+    @property
+    def number(self) -> int:
+        """Backward compatibility alias for track_number."""
+        return self.track_number
+
+    @number.setter
+    def number(self, value: int) -> None:
+        """Backward compatibility setter for track_number."""
+        self.track_number = value
 
     @property
     def path(self) -> Path:
@@ -51,29 +61,29 @@ class Track:
         return self.path.exists()
 
     @classmethod
-    def from_file(cls, file_path: str, number: int = 1) -> "Track":
+    def from_file(cls, file_path: str, track_number: int = 1) -> "Track":
         """Domain factory method: Create a track from a file path.
 
         Args:
             file_path: Path to the audio file
-            number: Position in the playlist (default: 1)
+            track_number: Position in the playlist (default: 1)
 
         Returns:
             A new Track domain entity
         """
         path = Path(file_path)
         return cls(
-            number=number, title=path.stem, filename=path.name, file_path=str(path)
+            track_number=track_number, title=path.stem, filename=path.name, file_path=str(path)
         )
 
     def __str__(self) -> str:
         """Domain representation of the track."""
-        return f"{self.number}. {self.title}"
+        return f"{self.track_number}. {self.title}"
 
     def is_valid(self) -> bool:
         """Domain business rule: Check if track has valid data."""
         return (
-            self.number > 0
+            self.track_number > 0
             and bool(self.title.strip())
             and bool(self.filename.strip())
             and bool(self.file_path.strip())

--- a/back/app/src/domain/data/services/playlist_service.py
+++ b/back/app/src/domain/data/services/playlist_service.py
@@ -415,7 +415,7 @@ class PlaylistService(BaseDomainService):
                 track_data = {
                     'id': str(uuid.uuid4()),
                     'playlist_id': playlist_id,
-                    'number': idx,
+                    'track_number': idx,
                     'title': audio_file.stem,
                     'filename': audio_file.name,
                     'file_path': str(audio_file),

--- a/back/app/src/domain/data/services/track_service.py
+++ b/back/app/src/domain/data/services/track_service.py
@@ -219,7 +219,7 @@ class TrackService(BaseDomainService):
         for idx, filename in enumerate(track_ids):
             internal_uuid = filename_to_uuid[filename]
             new_position = idx + 1
-            track_orders.append({'track_id': internal_uuid, 'number': new_position})
+            track_orders.append({'track_id': internal_uuid, 'track_number': new_position})
             logger.debug(f"Position {new_position}: {filename} → UUID {internal_uuid}")
 
         success = await self._track_repo.reorder(playlist_id, track_orders)

--- a/back/app/src/domain/data/services/track_service.py
+++ b/back/app/src/domain/data/services/track_service.py
@@ -50,7 +50,9 @@ class TrackService(BaseDomainService):
 
         tracks = await self._track_repo.get_by_playlist(playlist_id)
         # Handle both Track objects and dictionaries
-        return sorted(tracks, key=lambda t: t.number if hasattr(t, 'number') else t.get('number', 0))
+        # Track objects use .number property (backward compat for track_number)
+        # Dicts use 'track_number' per OpenAPI v4.1.0 (fallback to 'number' for backward compat)
+        return sorted(tracks, key=lambda t: t.number if hasattr(t, 'number') else t.get('track_number', t.get('number', 0)))
 
     @handle_domain_errors(operation_name="add_track")
     async def add_track(self, playlist_id: str, track_data: dict[str, Any]) -> dict[str, Any]:
@@ -76,7 +78,7 @@ class TrackService(BaseDomainService):
         full_track_data = {
             'id': track_id,
             'playlist_id': playlist_id,
-            'number': track_data.get('number', next_track_number),
+            'track_number': track_data.get('track_number', track_data.get('number', next_track_number)),  # OpenAPI v4.1.0
             'title': track_data.get('title', 'Unknown Track'),
             'filename': track_data.get('filename'),
             'file_path': track_data.get('file_path'),

--- a/back/app/src/domain/services/track_reordering_service.py
+++ b/back/app/src/domain/services/track_reordering_service.py
@@ -211,7 +211,7 @@ class TrackReorderingService:
 
             # Create new track with updated position using the actual Track model
             updated_track = Track(
-                number=position,  # New position
+                track_number=position,  # New position
                 title=original_track.title,
                 filename=original_track.filename,
                 file_path=original_track.file_path,

--- a/back/app/src/infrastructure/adapters/pure_playlist_repository_adapter.py
+++ b/back/app/src/infrastructure/adapters/pure_playlist_repository_adapter.py
@@ -62,7 +62,7 @@ class PurePlaylistRepositoryAdapter:
             Track domain entity
         """
         return Track(
-            track_number=track_data.get("number", 0),
+            track_number=track_data.get("track_number", track_data.get("number", 0)),
             title=track_data.get("title", "Unknown"),
             filename=track_data.get("filename", ""),
             file_path=track_data.get("file_path", ""),

--- a/back/app/src/infrastructure/adapters/pure_playlist_repository_adapter.py
+++ b/back/app/src/infrastructure/adapters/pure_playlist_repository_adapter.py
@@ -62,7 +62,7 @@ class PurePlaylistRepositoryAdapter:
             Track domain entity
         """
         return Track(
-            number=track_data.get("number", 0),
+            track_number=track_data.get("number", 0),
             title=track_data.get("title", "Unknown"),
             filename=track_data.get("filename", ""),
             file_path=track_data.get("file_path", ""),

--- a/back/app/src/infrastructure/repositories/data_playlist_repository.py
+++ b/back/app/src/infrastructure/repositories/data_playlist_repository.py
@@ -117,7 +117,7 @@ class DataPlaylistRepository(PlaylistRepositoryProtocol):
 
         return {
             'id': track.id,
-            'number': track.number,
+            'track_number': track.track_number,
             'title': track.title,
             'filename': track.filename,
             'file_path': track.file_path,

--- a/back/app/src/infrastructure/repositories/pure_sqlite_playlist_repository.py
+++ b/back/app/src/infrastructure/repositories/pure_sqlite_playlist_repository.py
@@ -546,7 +546,7 @@ class PureSQLitePlaylistRepository(PlaylistRepositoryProtocol):
 
             track = Track(
                 id=track_row["id"],
-                number=track_row["track_number"] if track_row["track_number"] else 1,
+                track_number=track_row["track_number"] if track_row["track_number"] else 1,
                 title=track_row["title"] if track_row["title"] else "Unknown",
                 filename=filename,
                 file_path=file_path,
@@ -682,7 +682,7 @@ class PureSQLitePlaylistRepository(PlaylistRepositoryProtocol):
         # Build track entity and convert to dict
         track = Track(
             id=track_row["id"],
-            number=track_row["track_number"] if track_row["track_number"] else 1,
+            track_number=track_row["track_number"] if track_row["track_number"] else 1,
             title=track_row["title"] if track_row["title"] else "Unknown",
             filename=filename,
             file_path=file_path,
@@ -724,7 +724,7 @@ class PureSQLitePlaylistRepository(PlaylistRepositoryProtocol):
         track_params = (
             track_id,
             playlist_id,
-            track_data.get('number', 1),
+            track_data.get('track_number', track_data.get('number', 1)),  # OpenAPI v4.1.0
             track_data.get('title', 'Unknown Track'),
             track_data.get('filename', ''),
             track_data.get('file_path', ''),
@@ -842,7 +842,7 @@ class PureSQLitePlaylistRepository(PlaylistRepositoryProtocol):
         operations = []
         for order in track_orders:
             track_id = order.get('track_id')
-            track_number = order.get('number')
+            track_number = order.get('track_number', order.get('number'))  # OpenAPI v4.1.0 with backward compat
 
             if not track_id or track_number is None:
                 logger.warning(f"Invalid track order entry: {order}")

--- a/back/app/src/services/broadcasting/unified_broadcasting_service.py
+++ b/back/app/src/services/broadcasting/unified_broadcasting_service.py
@@ -395,7 +395,9 @@ class UnifiedBroadcastingService:
         Validate and fix contract compliance for playlist data before broadcasting.
 
         This is a defense-in-depth measure to prevent issue #71 from recurring.
-        It detects and auto-fixes missing 'number' field in tracks.
+        It detects and auto-fixes missing 'track_number' field in tracks.
+
+        Per OpenAPI contract v4.1.0, tracks must have 'track_number' field.
 
         Args:
             playlist_data: Playlist data to validate
@@ -426,16 +428,16 @@ class UnifiedBroadcastingService:
                 fixed_tracks.append(track)
                 continue
 
-            # Check for 'number' field (required by frontend contract)
-            if 'number' not in track:
+            # Check for 'track_number' field (required by OpenAPI contract v4.1.0)
+            if 'track_number' not in track:
                 contract_violations_detected = True
 
-                # Try to fix by using 'number' if available
+                # Try to fix by using 'number' if available (backward compatibility)
                 if 'number' in track:
-                    track['number'] = track['number']
+                    track['track_number'] = track['number']
                     logger.warning(
                         f"CONTRACT VIOLATION FIXED: Track {idx} (ID: {track.get('id')}) "
-                        f"missing 'number' field, auto-fixed from 'number'={track['number']}. "
+                        f"missing 'track_number' field, auto-fixed from 'number'={track['track_number']}. "
                         f"This indicates a serialization bug (see issue #71). "
                         f"Track: {track.get('title', 'unknown')}"
                     )
@@ -443,21 +445,20 @@ class UnifiedBroadcastingService:
                     # Cannot fix - log critical error
                     logger.error(
                         f"CONTRACT VIOLATION CANNOT FIX: Track {idx} (ID: {track.get('id')}) "
-                        f"missing both 'number' and 'number' fields! "
+                        f"missing both 'track_number' and 'number' fields! "
                         f"Available fields: {', '.join(track.keys())}. "
                         f"Track: {track.get('title', 'unknown')}. "
                         f"This will cause frontend errors!"
                     )
 
-            # Verify 'number' and 'number' match if both present
-            if 'number' in track and 'number' in track:
-                if track['number'] != track['number']:
+            # Verify 'track_number' and 'number' match if both present (backward compatibility)
+            if 'track_number' in track and 'number' in track:
+                if track['track_number'] != track['number']:
                     logger.warning(
                         f"CONTRACT INCONSISTENCY: Track {idx} has mismatched fields: "
-                        f"number={track['number']} vs track_number={track['number']}. "
+                        f"track_number={track['track_number']} vs number={track['number']}. "
                         f"Using track_number as source of truth."
                     )
-                    track['number'] = track['number']
 
             fixed_tracks.append(track)
 
@@ -467,7 +468,7 @@ class UnifiedBroadcastingService:
             playlist_title = playlist_data.get('title', 'unknown')
             logger.warning(
                 f"CONTRACT VALIDATION: Playlist '{playlist_title}' (ID: {playlist_id}) "
-                f"had tracks with missing 'number' fields. Auto-fixed before broadcast. "
+                f"had tracks with missing 'track_number' fields. Auto-fixed before broadcast. "
                 f"This indicates serialization is not using UnifiedSerializationService. "
                 f"See issue #71 for context."
             )

--- a/back/app/src/services/filesystem_sync_service.py
+++ b/back/app/src/services/filesystem_sync_service.py
@@ -119,7 +119,7 @@ class FilesystemSyncService:
             duration_seconds = metadata.get("duration", 0)
             duration_ms = int(duration_seconds * 1000) if duration_seconds else 0
             track = {
-                "number": i,
+                "track_number": i,
                 "title": metadata.get("title", file_path.stem),
                 "filename": file_path.name,
                 "duration": duration_ms,  # Now in milliseconds like other services
@@ -177,7 +177,7 @@ class FilesystemSyncService:
         for filename in sorted(to_add):
             file_path = disk_files_map[filename]
             new_track = {
-                "number": track_number,
+                "track_number": track_number,
                 "title": file_path.stem,
                 "filename": filename,
                 "duration": "",

--- a/back/app/src/services/filesystem_sync_service.py
+++ b/back/app/src/services/filesystem_sync_service.py
@@ -170,7 +170,7 @@ class FilesystemSyncService:
         for filename, track in existing_tracks.items():
             if filename not in to_remove:
                 track_copy = dict(track)
-                track_copy["number"] = track_number
+                track_copy["track_number"] = track_number
                 new_tracks.append(track_copy)
                 track_number += 1
         # Add new tracks

--- a/back/app/src/services/player_state_service.py
+++ b/back/app/src/services/player_state_service.py
@@ -338,7 +338,7 @@ class PlayerStateService:
             file_size=track_data.get("file_size"),
             artist=track_data.get("artist"),
             album=track_data.get("album"),
-            track_number=track_data.get("number"),
+            track_number=track_data.get("track_number", track_data.get("number")),
             play_count=track_data.get("play_count", 0),
             created_at=track_data.get("created_at", datetime.now()),
             updated_at=track_data.get("updated_at"),

--- a/back/app/src/services/player_state_service.py
+++ b/back/app/src/services/player_state_service.py
@@ -338,7 +338,7 @@ class PlayerStateService:
             file_size=track_data.get("file_size"),
             artist=track_data.get("artist"),
             album=track_data.get("album"),
-            number=track_data.get("number"),
+            track_number=track_data.get("number"),
             play_count=track_data.get("play_count", 0),
             created_at=track_data.get("created_at", datetime.now()),
             updated_at=track_data.get("updated_at"),

--- a/back/app/src/services/serialization/unified_serialization_service.py
+++ b/back/app/src/services/serialization/unified_serialization_service.py
@@ -327,7 +327,7 @@ class UnifiedSerializationService:
                         )
                         state["active_track"] = active_track_data
                         state["active_track_id"] = active_track_data.get("id")
-                        state["active_track_number"] = active_track_data.get("number", current_track_index + 1)
+                        state["active_track_number"] = active_track_data.get("track_number", active_track_data.get("number", current_track_index + 1))
                         state["active_track_title"] = active_track_data.get("title", "")
                         state["duration_ms"] = active_track_data.get("duration_ms", 0)
             else:

--- a/back/app/src/services/serialization/unified_serialization_service.py
+++ b/back/app/src/services/serialization/unified_serialization_service.py
@@ -174,17 +174,17 @@ class UnifiedSerializationService:
         """
         # Handle different input types
         if isinstance(track, dict):
-            # Normalize dict to use 'number' field (OpenAPI contract)
-            # Support both 'track_number' (legacy) and 'number' (current)
+            # Normalize dict to use 'track_number' field (OpenAPI contract v4.1.0)
+            # Support both 'number' (legacy v3.x) and 'track_number' (current v4.1.0)
             track_data = track.copy()
-            if "track_number" in track_data and "number" not in track_data:
-                track_data["number"] = track_data["track_number"]
+            if "number" in track_data and "track_number" not in track_data:
+                track_data["track_number"] = track_data["number"]
         elif hasattr(track, "__dict__"):
             # Domain entity
-            # OpenAPI contract uses 'number', not 'number'
+            # OpenAPI contract v4.1.0 uses 'track_number'
             track_data = {
                 "id": getattr(track, "id", None),
-                "number": getattr(track, "number", 0),  # Fixed: use 'number' per OpenAPI contract
+                "track_number": getattr(track, "track_number", getattr(track, "number", 0)),  # OpenAPI v4.1.0
                 "title": getattr(track, "title", ""),
                 "filename": getattr(track, "filename", ""),
                 "file_path": getattr(track, "file_path", ""),
@@ -197,7 +197,7 @@ class UnifiedSerializationService:
             # Database row or tuple
             track_data = {
                 "id": track[0] if len(track) > 0 else None,
-                "number": track[1] if len(track) > 1 else 0,  # Fixed: use 'number' per OpenAPI contract
+                "track_number": track[1] if len(track) > 1 else 0,  # OpenAPI contract v4.1.0
                 "title": track[2] if len(track) > 2 else "",
                 "filename": track[3] if len(track) > 3 else "",
                 "file_path": track[4] if len(track) > 4 else "",
@@ -208,7 +208,7 @@ class UnifiedSerializationService:
         # Build base structure
         result = {
             "id": track_data.get("id"),
-            "number": track_data.get("number", 0),  # Fixed: use 'number' per OpenAPI contract
+            "track_number": track_data.get("track_number", track_data.get("number", 0)),  # OpenAPI contract v4.1.0
             "title": track_data.get("title", ""),
             "filename": track_data.get("filename", ""),
             "duration_ms": track_data.get("duration_ms", track_data.get("duration", 0)) or 0,
@@ -236,7 +236,7 @@ class UnifiedSerializationService:
             # WebSocket format is minimal
             result = {
                 "id": result["id"],
-                "number": result["number"],  # Fixed: use 'number' per OpenAPI contract
+                "track_number": result["track_number"],  # OpenAPI contract v4.1.0
                 "title": result["title"],
                 "duration_ms": result["duration_ms"],
             }
@@ -244,7 +244,7 @@ class UnifiedSerializationService:
             # Database format with all fields
             result = {
                 "id": result["id"],
-                "number": result["number"],  # Fixed: use 'number' per OpenAPI contract
+                "track_number": result["track_number"],  # OpenAPI contract v4.1.0
                 "title": result["title"],
                 "filename": result["filename"],
                 "file_path": track_data.get("file_path", ""),

--- a/back/app/src/services/track_progress_service.py
+++ b/back/app/src/services/track_progress_service.py
@@ -449,7 +449,7 @@ class TrackProgressService:
     @handle_service_errors("track_progress")
     async def _check_for_track_change(self, status: dict):
         """Check for track changes and emit state:track events to frontend."""
-        track_number = status.get("number")
+        track_number = status.get("track_number", status.get("number"))
         track_id = status.get("active_track_id")  # CRITICAL FIX: Use correct field name
         # Initialize last track info if needed
         if not hasattr(self, "_last_track_number"):

--- a/back/app/src/services/validation/unified_validation_service.py
+++ b/back/app/src/services/validation/unified_validation_service.py
@@ -188,14 +188,14 @@ class UnifiedValidationService:
                 }
             )
 
-        # Validate track number
-        track_number = data.get("number", 0)
+        # Validate track number (OpenAPI v4.1.0 uses track_number, fallback to number)
+        track_number = data.get("track_number", data.get("number", 0))
         if not isinstance(track_number, int) or track_number < 0:
             errors.append(
-                {"field": "number", "message": "Track number must be a non-negative integer"}
+                {"field": "track_number", "message": "Track number must be a non-negative integer"}
             )
         elif track_number > 9999:
-            errors.append({"field": "number", "message": "Track number too high (max 9999)"})
+            errors.append({"field": "track_number", "message": "Track number too high (max 9999)"})
 
         # Validate filename
         filename = data.get("filename", "").strip()

--- a/back/tests/conftest.py
+++ b/back/tests/conftest.py
@@ -207,7 +207,7 @@ def mock_playlist_with_tracks(test_client_with_mock_db):
         "created_at": "2025-01-01T00:00:00Z",
         "tracks": [
             {
-                "number": 1,
+                "track_number": 1,
                 "title": "Mock Song 1",
                 "filename": "mock1.mp3",
                 "duration": "3:00",
@@ -216,7 +216,7 @@ def mock_playlist_with_tracks(test_client_with_mock_db):
                 "play_counter": 0,
             },
             {
-                "number": 2,
+                "track_number": 2,
                 "title": "Mock Song 2",
                 "filename": "mock2.mp3",
                 "duration": "2:30",

--- a/back/tests/contracts/api_contracts.json
+++ b/back/tests/contracts/api_contracts.json
@@ -717,7 +717,7 @@
     "Track": {
       "type": "object",
       "properties": {
-        "number": {"type": "integer"},
+        "track_number": {"type": "integer"},
         "title": {"type": "string"},
         "filename": {"type": "string"},
         "file_path": {"type": "string"},
@@ -729,7 +729,7 @@
         "created_at": {"type": "string"},
         "updated_at": {"type": "string"}
       },
-      "required": ["number", "title", "filename"]
+      "required": ["track_number", "title", "filename"]
     },
     "PlayerState": {
       "type": "object",

--- a/back/tests/contracts/openapi.yaml
+++ b/back/tests/contracts/openapi.yaml
@@ -6,7 +6,7 @@ info:
 
     All API responses follow the UnifiedResponseService format with standardized envelopes.
     This specification is the source of truth for all client implementations (Web, Flutter, C++).
-  version: 3.1.0
+  version: 4.1.0
   contact:
     name: TheOpenMusicBox
     url: https://github.com/theopenmusicbox/tomb-rpi
@@ -93,13 +93,13 @@ components:
     Track:
       type: object
       required:
-        - number
+        - track_number
         - title
         - filename
       properties:
-        number:
+        track_number:
           type: integer
-          description: Track number in playlist
+          description: Track number in playlist (1-based position)
         title:
           type: string
         filename:
@@ -112,7 +112,7 @@ components:
           deprecated: true
           description: |
             DEPRECATED: Use duration_ms instead for millisecond precision.
-            Duration in seconds. Will be removed in v4.0.0.
+            Duration in seconds. Will be removed in a future version.
         duration_ms:
           type: integer
           nullable: true

--- a/back/tests/contracts/socketio_contracts.json
+++ b/back/tests/contracts/socketio_contracts.json
@@ -239,7 +239,7 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "number": {"type": "integer"},
+                    "track_number": {"type": "integer"},
                     "title": {"type": "string"},
                     "filename": {"type": "string"},
                     "duration": {"type": ["integer", "null"]},
@@ -247,7 +247,7 @@
                     "artist": {"type": ["string", "null"]},
                     "album": {"type": ["string", "null"]}
                   },
-                  "required": ["number", "title", "filename"]
+                  "required": ["track_number", "title", "filename"]
                 }
               },
               "nfc_tag_id": {"type": ["string", "null"]},
@@ -265,14 +265,14 @@
           "data_schema": {
             "type": "object",
             "properties": {
-              "number": {"type": "integer"},
+              "track_number": {"type": "integer"},
               "title": {"type": "string"},
               "filename": {"type": "string"},
               "duration": {"type": ["integer", "null"]},
               "duration_ms": {"type": ["integer", "null"]},
               "playlist_id": {"type": "string"}
             },
-            "required": ["number", "title", "filename", "playlist_id"]
+            "required": ["track_number", "title", "filename", "playlist_id"]
           },
           "description": "Track-level changes",
           "frequency": "on_demand"
@@ -363,13 +363,13 @@
               "track": {
                 "type": "object",
                 "properties": {
-                  "number": {"type": "integer"},
+                  "track_number": {"type": "integer"},
                   "title": {"type": "string"},
                   "filename": {"type": "string"},
                   "duration": {"type": ["integer", "null"]},
                   "duration_ms": {"type": ["integer", "null"]}
                 },
-                "required": ["number", "title", "filename"]
+                "required": ["track_number", "title", "filename"]
               }
             },
             "required": ["playlist_id", "track"]
@@ -606,7 +606,7 @@
               "track": {
                 "type": "object",
                 "properties": {
-                  "number": {"type": "integer"},
+                  "track_number": {"type": "integer"},
                   "title": {"type": "string"},
                   "filename": {"type": "string"},
                   "duration": {"type": ["integer", "null"]},

--- a/back/tests/contracts/test_playlist_api_contract.py
+++ b/back/tests/contracts/test_playlist_api_contract.py
@@ -175,8 +175,8 @@ class TestPlaylistAPIContract:
             "id": "test-playlist-123",
             "title": "Test Playlist",
             "tracks": [
-                {"number": 1, "title": "Track 1"},
-                {"number": 2, "title": "Track 2"}
+                {"track_number": 1, "title": "Track 1"},
+                {"track_number": 2, "title": "Track 2"}
             ]
         }
         routes._playlist_app_service.get_playlist_use_case = AsyncMock(
@@ -473,7 +473,7 @@ class TestPlaylistAPIContract:
                 json={
                     "source_playlist_id": "playlist-1",
                     "target_playlist_id": "playlist-2",
-                    "number": 3,
+                    "track_number": 3,
                     "target_position": 1,
                     "client_op_id": "client-op-move"
                 }

--- a/back/tests/contracts/test_track_serialization_contract.py
+++ b/back/tests/contracts/test_track_serialization_contract.py
@@ -33,7 +33,7 @@ class TestTrackSerializationContract:
         """Create a sample Track entity."""
         return Track(
             id="track-123",
-            number=1,
+            track_number=1,
             title="Test Track",
             filename="test.mp3",
             file_path="/path/to/test.mp3",
@@ -79,7 +79,7 @@ class TestTrackSerializationContract:
         serialized_fields = set(serialized.keys())
 
         # Verify 'number' field is present (no mapping needed anymore)
-        assert 'number' in serialized, (
+        assert 'track_number' in serialized, (
             "Track should have 'number' field after serialization"
         )
 
@@ -103,8 +103,8 @@ class TestTrackSerializationContract:
         assert hasattr(sample_track, 'number'), "Track should have 'number' attribute"
 
         # asdict() should serialize 'number' directly
-        assert 'number' in serialized, "asdict() should serialize 'number' field"
-        assert serialized['number'] == sample_track.number, "Serialized number should match entity"
+        assert 'track_number' in serialized, "asdict() should serialize 'number' field"
+        assert serialized['track_number'] == sample_track.number, "Serialized number should match entity"
 
     def test_repository_serialization_is_contract_compliant(self, sample_track, openapi_schema):
         """Test that Track serialization is contract compliant.
@@ -120,7 +120,7 @@ class TestTrackSerializationContract:
         serialized_fields = set(track_dict.keys())
 
         # Should have 'number' directly from asdict()
-        assert 'number' in track_dict, "Serialized track should have 'number' field per contract"
+        assert 'track_number' in track_dict, "Serialized track should have 'number' field per contract"
 
         # All required contract fields should be present
         missing = required_fields - serialized_fields
@@ -134,7 +134,7 @@ class TestTrackSerializationContract:
         tracks = [
             Track(
                 id=f"track-{i}",
-                number=i,
+                track_number=i,
                 title=f"Track {i}",
                 filename=f"track{i}.mp3",
                 file_path=f"/path/track{i}.mp3",
@@ -148,8 +148,8 @@ class TestTrackSerializationContract:
 
         # Verify all tracks have correct field names
         for i, track_dict in enumerate(serialized_tracks, 1):
-            assert 'number' in track_dict, f"Track {i} should have 'number' field"
-            assert track_dict['number'] == i, f"Track {i} should have number={i}"
+            assert 'track_number' in track_dict, f"Track {i} should have 'number' field"
+            assert track_dict['track_number'] == i, f"Track {i} should have number={i}"
 
     def test_reorder_tracks_response_contract(self):
         """Test that reordered tracks maintain contract compliance.
@@ -159,7 +159,7 @@ class TestTrackSerializationContract:
         """
         # Simulate reordering tracks
         original_tracks = [
-            Track(id=f"track-{i}", number=i, title=f"Track {i}",
+            Track(id=f"track-{i}", track_number=i, title=f"Track {i}",
                   filename=f"track{i}.mp3", file_path=f"/path/track{i}.mp3")
             for i in [1, 2, 3]
         ]
@@ -176,17 +176,17 @@ class TestTrackSerializationContract:
 
         # Verify sequential numbering
         for i, track_dict in enumerate(serialized, 1):
-            assert track_dict['number'] == i, (
+            assert track_dict['track_number'] == i, (
                 f"Reordered track at position {i} should have number={i}, got {track_dict.get('number')}"
             )
-            assert 'number' in track_dict, f"Track {i} must have 'number' field"
+            assert 'track_number' in track_dict, f"Track {i} must have 'number' field"
 
         # Verify no duplicates
-        numbers = [t['number'] for t in serialized]
+        numbers = [t['track_number'] for t in serialized]
         assert len(numbers) == len(set(numbers)), f"Duplicate track numbers found: {numbers}"
 
     @pytest.mark.parametrize("field_name,field_type", [
-        ("number", int),
+        ("track_number", int),  # OpenAPI v4.1.0
         ("title", str),
         ("filename", str),
     ])
@@ -256,8 +256,8 @@ class TestRepositorySerializationIntegration:
             track = serialized[0]
 
             # After refactoring, 'number' is directly available
-            assert 'number' in track, (
+            assert 'track_number' in track, (
                 "Serialized track should have 'number' field required by OpenAPI contract"
             )
-            assert track['number'] == 1
+            assert track['track_number'] == 1
             assert track['filename'] == 'track1.mp3'

--- a/back/tests/contracts/test_upload_endpoints_contract.py
+++ b/back/tests/contracts/test_upload_endpoints_contract.py
@@ -122,7 +122,7 @@ class TestUploadEndpointsContract:
 
         # Mock successful finalization
         mock_track = {
-            "number": 1,
+            "track_number": 1,
             "title": "Test Track",
             "filename": "test.mp3",
             "file_path": "/uploads/test.mp3",
@@ -308,7 +308,7 @@ class TestUploadEndpointsContract:
         app, routes = app_with_upload_routes
 
         mock_track = {
-            "number": 1,
+            "track_number": 1,
             "title": "Test Track",
             "filename": "test.mp3",
             "duration": 180000,

--- a/back/tests/functional/test_serialization_service.py
+++ b/back/tests/functional/test_serialization_service.py
@@ -28,7 +28,7 @@ class TestUnifiedSerializationService:
             "tracks": [
                 {
                     "id": "track-1",
-                    "number": 1,
+                    "track_number": 1,
                     "title": "Track 1",
                     "filename": "track1.mp3",
                     "duration_ms": None,  # This should not cause TypeError
@@ -37,7 +37,7 @@ class TestUnifiedSerializationService:
                 },
                 {
                     "id": "track-2",
-                    "number": 2,
+                    "track_number": 2,
                     "title": "Track 2",
                     "filename": "track2.mp3",
                     "duration_ms": 120000,  # Valid duration
@@ -46,7 +46,7 @@ class TestUnifiedSerializationService:
                 },
                 {
                     "id": "track-3",
-                    "number": 3,
+                    "track_number": 3,
                     "title": "Track 3",
                     "filename": "track3.mp3",
                     "duration_ms": 0,  # Zero duration
@@ -87,7 +87,7 @@ class TestUnifiedSerializationService:
         """Test that track serialization handles None values correctly."""
         track_data = {
             "id": "track-test",
-            "number": 1,
+            "track_number": 1,
             "title": "Test Track",
             "filename": "test.mp3",
             "duration_ms": None,  # Should be converted to 0
@@ -115,7 +115,7 @@ class TestUnifiedSerializationService:
             "tracks": [
                 {
                     "id": "track-1",
-                    "number": 1,
+                    "track_number": 1,
                     "title": "Test Track",
                     "duration_ms": 180000
                 }

--- a/back/tests/integration/test_nfc_association_to_playback_e2e.py
+++ b/back/tests/integration/test_nfc_association_to_playback_e2e.py
@@ -155,7 +155,7 @@ class TestNfcAssociationToPlaybackE2E:
             tracks=[
                 Track(
                     id=str(uuid.uuid4()),
-                    number=1,
+                    track_number=1,
                     title="Song One",
                     filename="song1.mp3",
                     file_path="/fake/path/song1.mp3",
@@ -163,7 +163,7 @@ class TestNfcAssociationToPlaybackE2E:
                 ),
                 Track(
                     id=str(uuid.uuid4()),
-                    number=2,
+                    track_number=2,
                     title="Song Two",
                     filename="song2.mp3",
                     file_path="/fake/path/song2.mp3",

--- a/back/tests/integration/test_nfc_integration_fixed.py
+++ b/back/tests/integration/test_nfc_integration_fixed.py
@@ -150,8 +150,8 @@ class TestNfcIntegration:
 
         # Test with dictionary objects (for backward compatibility)
         dict_tracks = [
-            {'id': 'track-1', 'number': 1, 'filename': 'track1.mp3'},
-            {'id': 'track-2', 'number': 2, 'filename': 'track2.mp3'}
+            {'id': 'track-1', 'track_number': 1, 'filename': 'track1.mp3'},
+            {'id': 'track-2', 'track_number': 2, 'filename': 'track2.mp3'}
         ]
 
         mock_track_repo.get_by_playlist.return_value = dict_tracks

--- a/back/tests/integration/test_nfc_integration_fixed.py
+++ b/back/tests/integration/test_nfc_integration_fixed.py
@@ -125,14 +125,14 @@ class TestNfcIntegration:
         track_objects = [
             Track(
                 id='track-1',
-                number=1,
+                track_number=1,
                 title='Track 1',
                 filename='track1.mp3',
                 file_path='/path/track1.mp3'
             ),
             Track(
                 id='track-2',
-                number=2,
+                track_number=2,
                 title='Track 2',
                 filename='track2.mp3',
                 file_path='/path/track2.mp3'

--- a/back/tests/integration/test_nfc_playlist_lookup_e2e.py
+++ b/back/tests/integration/test_nfc_playlist_lookup_e2e.py
@@ -70,14 +70,14 @@ class TestNfcPlaylistLookupE2E:
             tracks=[
                 Track(
                     id=str(uuid.uuid4()),
-                    number=1,
+                    track_number=1,
                     title="Track 1",
                     filename="track1.mp3",
                     file_path="/fake/path/track1.mp3"
                 ),
                 Track(
                     id=str(uuid.uuid4()),
-                    number=2,
+                    track_number=2,
                     title="Track 2",
                     filename="track2.mp3",
                     file_path="/fake/path/track2.mp3"
@@ -203,7 +203,7 @@ class TestNfcPlaylistLookupE2E:
                 tracks=[
                     Track(
                         id=str(uuid.uuid4()),
-                        number=1,
+                        track_number=1,
                         title="Test Track 1",
                         filename="test1.mp3",
                         file_path=test_file_path,

--- a/back/tests/integration/test_nfc_workflow_e2e.py
+++ b/back/tests/integration/test_nfc_workflow_e2e.py
@@ -166,7 +166,7 @@ class TestNfcWorkflowE2E:
             tracks=[
                 Track(
                     id=str(uuid.uuid4()),
-                    number=1,
+                    track_number=1,
                     title="Test Song",
                     filename="test.mp3",
                     file_path="/fake/path/test.mp3",
@@ -289,7 +289,7 @@ class TestNfcWorkflowE2E:
             tracks=[
                 Track(
                     id=str(uuid.uuid4()),
-                    number=1,
+                    track_number=1,
                     title="Override Song",
                     filename="override.mp3",
                     file_path="/fake/path/override.mp3",

--- a/back/tests/integration/test_upload_controller_integration.py
+++ b/back/tests/integration/test_upload_controller_integration.py
@@ -299,7 +299,7 @@ class TestUploadControllerIntegration:
         assert result["track"]["title"] == "Test Track"
         assert result["track"]["artist"] == "Test Artist"
         assert result["track"]["album"] == "Test Album"
-        assert result["track"]["number"] == 1
+        assert result["track"]["track_number"] == 1
 
         # Verify Socket.IO emit was called
         mock_socketio.emit.assert_called_once()

--- a/back/tests/test_domain_models.py
+++ b/back/tests/test_domain_models.py
@@ -22,7 +22,7 @@ class TestTrackDomainEntity:
     def test_track_creation(self):
         """Test basic track creation."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Test Song",
             filename="test.mp3",
             file_path="/music/test.mp3",
@@ -42,7 +42,7 @@ class TestTrackDomainEntity:
     def test_track_domain_properties(self):
         """Test domain-specific properties."""
         track = Track(
-            number=5,
+            track_number=5,
             title="Test Track",
             filename="track.mp3",
             file_path="/music/track.mp3",
@@ -57,7 +57,7 @@ class TestTrackDomainEntity:
     def test_track_validation_business_rule(self):
         """Test domain business rule: track validation."""
         valid_track = Track(
-            number=1,
+            track_number=1,
             title="Valid Track",
             filename="valid.mp3",
             file_path="/music/valid.mp3"
@@ -67,7 +67,7 @@ class TestTrackDomainEntity:
         
         # Invalid track: negative track number
         invalid_track = Track(
-            number=-1,
+            track_number=-1,
             title="Invalid Track",
             filename="invalid.mp3",
             file_path="/music/invalid.mp3"
@@ -77,7 +77,7 @@ class TestTrackDomainEntity:
         
         # Invalid track: empty title
         invalid_track2 = Track(
-            number=1,
+            track_number=1,
             title="",
             filename="empty.mp3",
             file_path="/music/empty.mp3"
@@ -89,7 +89,7 @@ class TestTrackDomainEntity:
         """Test domain service for display name formatting."""
         # Track without artist
         track1 = Track(
-            number=1,
+            track_number=1,
             title="Song Title",
             filename="song.mp3",
             file_path="/music/song.mp3"
@@ -99,7 +99,7 @@ class TestTrackDomainEntity:
         
         # Track with artist
         track2 = Track(
-            number=1,
+            track_number=1,
             title="Song Title",
             filename="song.mp3",
             file_path="/music/song.mp3",
@@ -121,7 +121,7 @@ class TestTrackDomainEntity:
         """Test track validation edge cases."""
         # Valid track with minimal data
         valid_track = Track(
-            number=1,
+            track_number=1,
             title="Valid",
             filename="valid.mp3",
             file_path="/valid.mp3"
@@ -130,7 +130,7 @@ class TestTrackDomainEntity:
         
         # Invalid: zero track number
         invalid_track = Track(
-            number=0,
+            track_number=0,
             title="Invalid",
             filename="invalid.mp3",
             file_path="/invalid.mp3"
@@ -139,7 +139,7 @@ class TestTrackDomainEntity:
         
         # Invalid: whitespace-only title
         whitespace_track = Track(
-            number=1,
+            track_number=1,
             title="   ",  # Only whitespace
             filename="whitespace.mp3",
             file_path="/whitespace.mp3"
@@ -148,7 +148,7 @@ class TestTrackDomainEntity:
         
         # Invalid: empty filename
         empty_filename_track = Track(
-            number=1,
+            track_number=1,
             title="Good Title",
             filename="",
             file_path="/good/path.mp3"
@@ -157,7 +157,7 @@ class TestTrackDomainEntity:
         
         # Invalid: empty file_path
         empty_path_track = Track(
-            number=1,
+            track_number=1,
             title="Good Title",
             filename="good.mp3",
             file_path=""
@@ -168,7 +168,7 @@ class TestTrackDomainEntity:
         """Test duration conversion from milliseconds to seconds."""
         # Track with duration
         track_with_duration = Track(
-            number=1,
+            track_number=1,
             title="Timed Track",
             filename="timed.mp3",
             file_path="/timed.mp3",
@@ -178,7 +178,7 @@ class TestTrackDomainEntity:
         
         # Track without duration
         track_no_duration = Track(
-            number=1,
+            track_number=1,
             title="No Time",
             filename="notime.mp3",
             file_path="/notime.mp3",
@@ -189,7 +189,7 @@ class TestTrackDomainEntity:
     def test_track_number_property_alias(self):
         """Test number property alias for API compatibility."""
         track = Track(
-            number=5,
+            track_number=5,
             title="Test Track",
             filename="test.mp3",
             file_path="/test.mp3"
@@ -206,7 +206,7 @@ class TestTrackDomainEntity:
     def test_track_string_representation(self):
         """Test track string representation."""
         track = Track(
-            number=3,
+            track_number=3,
             title="My Song",
             filename="mysong.mp3",
             file_path="/music/mysong.mp3"
@@ -246,14 +246,14 @@ class TestPlaylistDomainEntity:
         playlist = Playlist(title="Test Playlist")
         
         track1 = Track(
-            number=1,
+            track_number=1,
             title="Track 1",
             filename="track1.mp3",
             file_path="/music/track1.mp3"
         )
         
         track2 = Track(
-            number=2,
+            track_number=2,
             title="Track 2",
             filename="track2.mp3",
             file_path="/music/track2.mp3"
@@ -273,7 +273,7 @@ class TestPlaylistDomainEntity:
         
         # Track with number 0 should be auto-assigned
         track = Track(
-            number=0,
+            track_number=0,
             title="Auto Number Track",
             filename="auto.mp3",
             file_path="/music/auto.mp3"
@@ -289,7 +289,7 @@ class TestPlaylistDomainEntity:
         # Valid playlist
         valid_playlist = Playlist(title="Valid Playlist")
         valid_track = Track(
-            number=1,
+            track_number=1,
             title="Valid Track",
             filename="valid.mp3",
             file_path="/music/valid.mp3"
@@ -305,7 +305,7 @@ class TestPlaylistDomainEntity:
         # Invalid playlist: contains invalid track
         invalid_playlist2 = Playlist(title="Invalid Playlist")
         invalid_track = Track(
-            number=-1,
+            track_number=-1,
             title="",
             filename="",
             file_path=""
@@ -318,8 +318,8 @@ class TestPlaylistDomainEntity:
         """Test domain services for playlist operations."""
         playlist = Playlist(title="Service Test Playlist")
         
-        track1 = Track(number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3")
-        track2 = Track(number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3")
+        track1 = Track(track_number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3")
+        track2 = Track(track_number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3")
         
         playlist.add_track(track1)
         playlist.add_track(track2)
@@ -338,9 +338,9 @@ class TestPlaylistDomainEntity:
         playlist = Playlist(title="Normalize Test")
         
         # Add tracks with non-sequential numbers
-        track1 = Track(number=5, title="Track 5", filename="t5.mp3", file_path="/t5.mp3")
-        track2 = Track(number=3, title="Track 3", filename="t3.mp3", file_path="/t3.mp3")
-        track3 = Track(number=8, title="Track 8", filename="t8.mp3", file_path="/t8.mp3")
+        track1 = Track(track_number=5, title="Track 5", filename="t5.mp3", file_path="/t5.mp3")
+        track2 = Track(track_number=3, title="Track 3", filename="t3.mp3", file_path="/t3.mp3")
+        track3 = Track(track_number=8, title="Track 8", filename="t8.mp3", file_path="/t8.mp3")
         
         playlist.add_track(track1)
         playlist.add_track(track2)
@@ -356,9 +356,9 @@ class TestPlaylistDomainEntity:
         """Test domain service: total duration calculation."""
         playlist = Playlist(title="Duration Test")
         
-        track1 = Track(number=1, title="Track 1", filename="t1.mp3", 
+        track1 = Track(track_number=1, title="Track 1", filename="t1.mp3", 
                       file_path="/t1.mp3", duration_ms=180000)  # 3 minutes
-        track2 = Track(number=2, title="Track 2", filename="t2.mp3", 
+        track2 = Track(track_number=2, title="Track 2", filename="t2.mp3", 
                       file_path="/t2.mp3", duration_ms=240000)  # 4 minutes
         
         playlist.add_track(track1)
@@ -388,7 +388,7 @@ class TestPlaylistDomainEntity:
         
         # Playlist with tracks
         playlist = Playlist(title="My Songs")
-        track = Track(number=1, title="Song", filename="song.mp3", file_path="/song.mp3")
+        track = Track(track_number=1, title="Song", filename="song.mp3", file_path="/song.mp3")
         playlist.add_track(track)
         
         assert playlist.get_display_name() == "My Songs (1 tracks)"
@@ -404,7 +404,7 @@ class TestPlaylistDomainEntity:
         assert playlist.has_track_number(1) is False
         
         # Test with single track
-        track = Track(number=5, title="Single", filename="single.mp3", file_path="/single.mp3")
+        track = Track(track_number=5, title="Single", filename="single.mp3", file_path="/single.mp3")
         playlist.add_track(track)
         
         assert playlist.get_track_numbers() == [5]
@@ -430,8 +430,8 @@ class TestPlaylistDomainEntity:
         assert playlist.get_track_by_position(-1) is None
         
         # Add tracks
-        track1 = Track(number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3")
-        track2 = Track(number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3")
+        track1 = Track(track_number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3")
+        track2 = Track(track_number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3")
         playlist.add_track(track1)
         playlist.add_track(track2)
         
@@ -451,8 +451,8 @@ class TestPlaylistDomainEntity:
         assert playlist.get_total_duration_ms() == 0
         
         # Tracks with unknown duration
-        track1 = Track(number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3", duration_ms=None)
-        track2 = Track(number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3", duration_ms=180000)
+        track1 = Track(track_number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3", duration_ms=None)
+        track2 = Track(track_number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3", duration_ms=180000)
         playlist.add_track(track1)
         playlist.add_track(track2)
         

--- a/back/tests/unit/api/test_playlist_broadcasting_fix.py
+++ b/back/tests/unit/api/test_playlist_broadcasting_fix.py
@@ -34,8 +34,8 @@ async def test_broadcast_playlist_updated_sends_full_playlist_data():
         "track_count": 5,
         "nfc_tag_id": None,
         "tracks": [
-            {"id": "track-1", "title": "Track 1", "number": 1, "filename": "track1.mp3"},
-            {"id": "track-2", "title": "Track 2", "number": 2, "filename": "track2.mp3"},
+            {"id": "track-1", "title": "Track 1", "track_number": 1, "filename": "track1.mp3"},
+            {"id": "track-2", "title": "Track 2", "track_number": 2, "filename": "track2.mp3"},
         ]
     })
 
@@ -136,9 +136,9 @@ async def test_broadcast_tracks_reordered_sends_via_playlists_snapshot():
         "title": "Reordered Playlist",
         "track_count": 3,
         "tracks": [
-            {"id": "track-3", "title": "Track 3", "number": 1, "filename": "track3.mp3"},
-            {"id": "track-1", "title": "Track 1", "number": 2, "filename": "track1.mp3"},
-            {"id": "track-2", "title": "Track 2", "number": 3, "filename": "track2.mp3"},
+            {"id": "track-3", "title": "Track 3", "track_number": 1, "filename": "track3.mp3"},
+            {"id": "track-1", "title": "Track 1", "track_number": 2, "filename": "track1.mp3"},
+            {"id": "track-2", "title": "Track 2", "track_number": 3, "filename": "track2.mp3"},
         ]
     })
 
@@ -178,9 +178,9 @@ async def test_broadcast_tracks_reordered_sends_via_playlists_snapshot():
     assert len(playlist["tracks"]) == 3
 
     # Verify track order is correct
-    assert playlist["tracks"][0]["number"] == 1
+    assert playlist["tracks"][0]["track_number"] == 1
     assert playlist["tracks"][0]["id"] == "track-3"
-    assert playlist["tracks"][1]["number"] == 2
+    assert playlist["tracks"][1]["track_number"] == 2
     assert playlist["tracks"][1]["id"] == "track-1"
 
     print("✅ Track reordering broadcasts via state:playlists - Frontend will receive it")

--- a/back/tests/unit/api/test_playlist_broadcasting_service.py
+++ b/back/tests/unit/api/test_playlist_broadcasting_service.py
@@ -91,7 +91,7 @@ class TestPlaylistBroadcastingService:
         """Test broadcasting track addition event."""
         # Arrange
         playlist_id = "test-playlist-id"
-        track_data = {"id": "track-1", "title": "Test Track", "number": 1}
+        track_data = {"id": "track-1", "title": "Test Track", "track_number": 1}
 
         # Act
         await broadcasting_service.broadcast_track_added(playlist_id, track_data)

--- a/back/tests/unit/api/test_playlist_operations_service.py
+++ b/back/tests/unit/api/test_playlist_operations_service.py
@@ -53,9 +53,9 @@ class TestPlaylistOperationsService:
         mock_playlist_data = {
             "id": playlist_id,
             "tracks": [
-                {"id": "t1", "number": 1, "title": "Track 1", "filename": "track1.mp3", "file_path": "/path/t1"},
-                {"id": "t2", "number": 2, "title": "Track 2", "filename": "track2.mp3", "file_path": "/path/t2"},
-                {"id": "t3", "number": 3, "title": "Track 3", "filename": "track3.mp3", "file_path": "/path/t3"},
+                {"id": "t1", "track_number": 1, "title": "Track 1", "filename": "track1.mp3", "file_path": "/path/t1"},
+                {"id": "t2", "track_number": 2, "title": "Track 2", "filename": "track2.mp3", "file_path": "/path/t2"},
+                {"id": "t3", "track_number": 3, "title": "Track 3", "filename": "track3.mp3", "file_path": "/path/t3"},
             ]
         }
         mock_repository_adapter.get_playlist_by_id.return_value = mock_playlist_data
@@ -106,7 +106,7 @@ class TestPlaylistOperationsService:
         mock_playlist_data = {
             "id": playlist_id,
             "tracks": [
-                {"id": "t1", "number": 1, "title": "Track 1", "filename": "track1.mp3", "file_path": "/path/t1"},
+                {"id": "t1", "track_number": 1, "title": "Track 1", "filename": "track1.mp3", "file_path": "/path/t1"},
             ]
         }
         mock_repository_adapter.get_playlist_by_id.return_value = mock_playlist_data
@@ -135,9 +135,9 @@ class TestPlaylistOperationsService:
         track_numbers = [1, 3]
         mock_playlist_data = {
             "tracks": [
-                {"number": 1, "title": "Track 1"},
-                {"number": 2, "title": "Track 2"},
-                {"number": 3, "title": "Track 3"},
+                {"track_number": 1, "title": "Track 1"},
+                {"track_number": 2, "title": "Track 2"},
+                {"track_number": 3, "title": "Track 3"},
             ]
         }
         mock_repository_adapter.get_playlist_by_id.return_value = mock_playlist_data
@@ -153,7 +153,7 @@ class TestPlaylistOperationsService:
         call_args = mock_repository_adapter.replace_tracks.call_args
         remaining_tracks = call_args[0][1]
         assert len(remaining_tracks) == 1
-        assert remaining_tracks[0]["number"] == 2
+        assert remaining_tracks[0]["track_number"] == 2
 
     @pytest.mark.asyncio
     async def test_delete_tracks_playlist_not_found(self, operations_service, mock_repository_adapter):
@@ -336,9 +336,9 @@ class TestPlaylistOperationsService:
         mock_playlist_data = {
             "id": playlist_id,
             "tracks": [
-                {"number": 1, "title": "Track 1"},
-                {"number": 2, "title": "Track 2"},
-                {"number": 3, "title": "Track 3"},
+                {"track_number": 1, "title": "Track 1"},
+                {"track_number": 2, "title": "Track 2"},
+                {"track_number": 3, "title": "Track 3"},
             ]
         }
         mock_playlist_app_service.get_playlist_use_case.return_value = {
@@ -362,9 +362,9 @@ class TestPlaylistOperationsService:
         mock_playlist_data = {
             "id": playlist_id,
             "tracks": [
-                {"number": 1, "title": "Track 1"},
-                {"number": 3, "title": "Track 3"},  # Missing track 2
-                {"number": 5, "title": "Track 5"},  # Wrong number
+                {"track_number": 1, "title": "Track 1"},
+                {"track_number": 3, "title": "Track 3"},  # Missing track 2
+                {"track_number": 5, "title": "Track 5"},  # Wrong number
             ]
         }
         mock_playlist_app_service.get_playlist_use_case.return_value = {

--- a/back/tests/unit/application/controllers/test_upload_controller.py
+++ b/back/tests/unit/application/controllers/test_upload_controller.py
@@ -402,7 +402,7 @@ class TestUploadFinalization:
 
         controller.playlist_app_service.get_playlist_use_case = AsyncMock(return_value={
             "id": "pl-123",
-            "tracks": [{"number": 1}]
+            "tracks": [{"track_number": 1}]
         })
 
         result = await controller.finalize_upload(
@@ -412,7 +412,7 @@ class TestUploadFinalization:
 
         assert result["status"] == "success"
         assert "track" in result
-        assert result["track"]["number"] == 2  # After existing track
+        assert result["track"]["track_number"] == 2  # After existing track
 
     @pytest.mark.asyncio
     async def test_finalize_with_metadata_override(self, controller):

--- a/back/tests/unit/application/services/test_audio_application_service.py
+++ b/back/tests/unit/application/services/test_audio_application_service.py
@@ -112,7 +112,7 @@ class TestAudioApplicationService:
                 "title": "Test Playlist",
                 "tracks": [
                     {
-                        "number": 1,
+                        "track_number": 1,
                         "title": "Song 1",
                         "filename": "song1.mp3",
                         "file_path": "/path/to/song1.mp3",
@@ -142,7 +142,7 @@ class TestAudioApplicationService:
             "playlist": {
                 "id": playlist_id,
                 "title": "Test Playlist",
-                "tracks": [{"number": 1, "title": "Song 1", "filename": "song1.mp3"}]
+                "tracks": [{"track_number": 1, "title": "Song 1", "filename": "song1.mp3"}]
             }
         }
         mock_audio_container.audio_engine.set_playlist.return_value = True
@@ -218,7 +218,7 @@ class TestAudioApplicationService:
             "status": "success",
             "playlist": {
                 "id": playlist_id,
-                "tracks": [{"number": 1, "title": "Song 1", "filename": "song1.mp3"}]
+                "tracks": [{"track_number": 1, "title": "Song 1", "filename": "song1.mp3"}]
             }
         }
         mock_audio_container.audio_engine.set_playlist.return_value = False
@@ -243,7 +243,7 @@ class TestAudioApplicationService:
             "status": "success",
             "playlist": {
                 "id": playlist_id,
-                "tracks": [{"number": 1, "title": "Song 1"}]
+                "tracks": [{"track_number": 1, "title": "Song 1"}]
             }
         }
 

--- a/back/tests/unit/application/services/test_state_serialization_application_service.py
+++ b/back/tests/unit/application/services/test_state_serialization_application_service.py
@@ -165,7 +165,7 @@ class TestStateSerializationApplicationService:
         assert result["duration_ms"] == 180500  # Converted to milliseconds
         assert result["artist"] == "Object Artist"
         assert result["album"] == "Object Album"
-        assert result["number"] == 3  # Fixed: OpenAPI contract uses 'number' not 'number'
+        assert result["track_number"] == 3  # Fixed: OpenAPI contract uses 'number' not 'number'
         assert result["play_count"] == 42
         assert result["created_at"] == "2023-01-01T00:00:00Z"
         assert result["server_seq"] == 100

--- a/back/tests/unit/application/test_data_application_service.py
+++ b/back/tests/unit/application/test_data_application_service.py
@@ -265,9 +265,9 @@ class TestDataApplicationService:
 
         # Mock tracks exist
         mock_track_service.get_tracks.return_value = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'},
-            {'id': 'track-3', 'number': 3, 'title': 'Track 3'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'},
+            {'id': 'track-3', 'track_number': 3, 'title': 'Track 3'}
         ]
 
         # Mock successful deletion

--- a/back/tests/unit/domain/data/test_playlist_events.py
+++ b/back/tests/unit/domain/data/test_playlist_events.py
@@ -151,7 +151,7 @@ class TestTrackAddedEvent:
             track_id="track-123",
             playlist_id="pl-456",
             track_name="New Song",
-            number=5,
+            track_number=5,
             added_at=now
         )
 
@@ -167,7 +167,7 @@ class TestTrackAddedEvent:
             track_id="track-1",
             playlist_id="pl-1",
             track_name="First Track",
-            number=1,
+            track_number=1,
             added_at=datetime.now(timezone.utc)
         )
 
@@ -179,7 +179,7 @@ class TestTrackAddedEvent:
             track_id="track-1",
             playlist_id="pl-1",
             track_name="Track",
-            number=999,
+            track_number=999,
             added_at=datetime.now(timezone.utc)
         )
 

--- a/back/tests/unit/domain/data/test_playlist_model.py
+++ b/back/tests/unit/domain/data/test_playlist_model.py
@@ -388,7 +388,7 @@ class TestPlaylistBusinessRules:
         """Test playlist with invalid track is invalid."""
         playlist = Playlist(title="Test")
         invalid_track = Track(
-            number=0,  # Invalid: must be > 0
+            track_number=0,  # Invalid: must be > 0
             title="",
             filename="",
             file_path=""

--- a/back/tests/unit/domain/data/test_playlist_service.py
+++ b/back/tests/unit/domain/data/test_playlist_service.py
@@ -70,12 +70,12 @@ class TestPlaylistService:
         # Create Playlist entities
         playlist_entities = [
             Playlist(id="playlist-1", title="Test Playlist 1", tracks=[
-                Track(number=1, title="Track 1", filename="path1.mp3", file_path="/fake/path1.mp3", id="track-1"),
-                Track(number=2, title="Track 2", filename="path2.mp3", file_path="/fake/path2.mp3", id="track-2")
+                Track(track_number=1, title="Track 1", filename="path1.mp3", file_path="/fake/path1.mp3", id="track-1"),
+                Track(track_number=2, title="Track 2", filename="path2.mp3", file_path="/fake/path2.mp3", id="track-2")
             ]),
             Playlist(id="playlist-2", title="Test Playlist 2", tracks=[
-                Track(number=1, title="Track 3", filename="path3.mp3", file_path="/fake/path3.mp3", id="track-3"),
-                Track(number=2, title="Track 4", filename="path4.mp3", file_path="/fake/path4.mp3", id="track-4")
+                Track(track_number=1, title="Track 3", filename="path3.mp3", file_path="/fake/path3.mp3", id="track-3"),
+                Track(track_number=2, title="Track 4", filename="path4.mp3", file_path="/fake/path4.mp3", id="track-4")
             ])
         ]
         mock_playlist_repo.find_all.return_value = playlist_entities
@@ -96,7 +96,7 @@ class TestPlaylistService:
         playlist_entity = Playlist(
             id="playlist-1",
             title="Test Playlist",
-            tracks=[Track(number=1, title="Track 1", filename="path.mp3", file_path="/fake/path.mp3", id="track-1")]
+            tracks=[Track(track_number=1, title="Track 1", filename="path.mp3", file_path="/fake/path.mp3", id="track-1")]
         )
 
         mock_playlist_repo.find_by_id.return_value = playlist_entity
@@ -241,7 +241,7 @@ class TestPlaylistService:
             id='playlist-1',
             title='NFC Playlist',
             nfc_tag_id=nfc_tag_id,
-            tracks=[Track(number=1, title='Track 1', filename='track1.mp3', file_path='/fake/track1.mp3', id='track-1')]
+            tracks=[Track(track_number=1, title='Track 1', filename='track1.mp3', file_path='/fake/track1.mp3', id='track-1')]
         )
 
         mock_playlist_repo.find_by_nfc_tag.return_value = playlist_entity
@@ -386,8 +386,8 @@ class TestPlaylistService:
         # Mock existing tracks - track2 no longer exists on disk
         from app.src.domain.data.models.track import Track
         existing_tracks = [
-            Track(id='track-1', number=1, title='Track 1', filename='track1.mp3', file_path='/tmp/track1.mp3'),
-            Track(id='track-2', number=2, title='Track 2', filename='track2.mp3', file_path='/tmp/track2.mp3')  # File deleted
+            Track(id='track-1', track_number=1, title='Track 1', filename='track1.mp3', file_path='/tmp/track1.mp3'),
+            Track(id='track-2', track_number=2, title='Track 2', filename='track2.mp3', file_path='/tmp/track2.mp3')  # File deleted
         ]
         mock_track_repo.get_tracks_by_playlist.return_value = existing_tracks
         mock_track_repo.delete_track.return_value = True

--- a/back/tests/unit/domain/data/test_track_model.py
+++ b/back/tests/unit/domain/data/test_track_model.py
@@ -21,7 +21,7 @@ class TestTrackConstruction:
     def test_create_track_minimal(self):
         """Test creating track with minimal required fields."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Test Song",
             filename="test.mp3",
             file_path="/music/test.mp3"
@@ -39,7 +39,7 @@ class TestTrackConstruction:
     def test_create_track_full(self):
         """Test creating track with all fields."""
         track = Track(
-            number=5,
+            track_number=5,
             title="Complete Song",
             filename="complete.flac",
             file_path="/music/albums/complete.flac",
@@ -73,7 +73,7 @@ class TestTrackFactoryMethods:
 
     def test_from_file_with_track_number(self):
         """Test creating track from file with custom track number."""
-        track = Track.from_file("/music/song.mp3", number=10)
+        track = Track.from_file("/music/song.mp3", track_number=10)
 
         assert track.number == 10
 
@@ -159,7 +159,7 @@ class TestTrackValidation:
     def test_is_valid_true(self):
         """Test valid track."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Valid Song",
             filename="valid.mp3",
             file_path="/music/valid.mp3"
@@ -170,7 +170,7 @@ class TestTrackValidation:
     def test_is_valid_zero_track_number(self):
         """Test track with zero track number is invalid."""
         track = Track(
-            number=0,
+            track_number=0,
             title="Invalid",
             filename="invalid.mp3",
             file_path="/music/invalid.mp3"
@@ -181,7 +181,7 @@ class TestTrackValidation:
     def test_is_valid_negative_track_number(self):
         """Test track with negative track number is invalid."""
         track = Track(
-            number=-1,
+            track_number=-1,
             title="Invalid",
             filename="invalid.mp3",
             file_path="/music/invalid.mp3"
@@ -192,7 +192,7 @@ class TestTrackValidation:
     def test_is_valid_empty_title(self):
         """Test track with empty title is invalid."""
         track = Track(
-            number=1,
+            track_number=1,
             title="",
             filename="file.mp3",
             file_path="/music/file.mp3"
@@ -203,7 +203,7 @@ class TestTrackValidation:
     def test_is_valid_whitespace_title(self):
         """Test track with whitespace-only title is invalid."""
         track = Track(
-            number=1,
+            track_number=1,
             title="   ",
             filename="file.mp3",
             file_path="/music/file.mp3"
@@ -214,7 +214,7 @@ class TestTrackValidation:
     def test_is_valid_empty_filename(self):
         """Test track with empty filename is invalid."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Title",
             filename="",
             file_path="/music/file.mp3"
@@ -225,7 +225,7 @@ class TestTrackValidation:
     def test_is_valid_empty_file_path(self):
         """Test track with empty file path is invalid."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Title",
             filename="file.mp3",
             file_path=""
@@ -236,7 +236,7 @@ class TestTrackValidation:
     def test_is_valid_all_fields_valid_but_optional_missing(self):
         """Test track is valid even without optional fields."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Title",
             filename="file.mp3",
             file_path="/music/file.mp3",
@@ -263,7 +263,7 @@ class TestTrackDisplayMethods:
     def test_str_representation_with_custom_title(self):
         """Test string representation with custom title."""
         track = Track(
-            number=3,
+            track_number=3,
             title="Custom Title",
             filename="file.mp3",
             file_path="/music/file.mp3"
@@ -341,7 +341,7 @@ class TestTrackEdgeCases:
     def test_unicode_title(self):
         """Test track with unicode characters in title."""
         track = Track(
-            number=1,
+            track_number=1,
             title="日本語のタイトル 🎵",
             filename="japanese.mp3",
             file_path="/music/japanese.mp3"
@@ -354,7 +354,7 @@ class TestTrackEdgeCases:
         """Test track with very long title."""
         long_title = "A" * 1000
         track = Track(
-            number=1,
+            track_number=1,
             title=long_title,
             filename="long.mp3",
             file_path="/music/long.mp3"
@@ -373,7 +373,7 @@ class TestTrackEdgeCases:
     def test_relative_file_path(self):
         """Test track with relative file path."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Relative",
             filename="song.mp3",
             file_path="./music/song.mp3"
@@ -391,7 +391,7 @@ class TestTrackEdgeCases:
 
     def test_track_number_very_large(self):
         """Test track with very large track number."""
-        track = Track.from_file("/song.mp3", number=999999)
+        track = Track.from_file("/song.mp3", track_number=999999)
 
         assert track.number == 999999
         assert track.is_valid() is True
@@ -409,7 +409,7 @@ class TestTrackEdgeCases:
     def test_metadata_fields_optional(self):
         """Test that metadata fields are truly optional."""
         track = Track(
-            number=1,
+            track_number=1,
             title="Minimal",
             filename="minimal.mp3",
             file_path="/minimal.mp3"

--- a/back/tests/unit/domain/data/test_track_service.py
+++ b/back/tests/unit/domain/data/test_track_service.py
@@ -44,8 +44,8 @@ class TestTrackService:
         """Test getting tracks for a playlist."""
         playlist_id = 'playlist-1'
         tracks_data = [
-            {'id': 'track-1', 'number': 2, 'title': 'Track 2'},
-            {'id': 'track-2', 'number': 1, 'title': 'Track 1'}
+            {'id': 'track-1', 'track_number': 2, 'title': 'Track 2'},
+            {'id': 'track-2', 'track_number': 1, 'title': 'Track 1'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -55,8 +55,8 @@ class TestTrackService:
 
         # Should be sorted by track_number
         assert len(result) == 2
-        assert result[0]['number'] == 1
-        assert result[1]['number'] == 2
+        assert result[0]['track_number'] == 1
+        assert result[1]['track_number'] == 2
 
     @pytest.mark.asyncio
     async def test_get_tracks_playlist_not_found(self, service, mock_track_repo, mock_playlist_repo):
@@ -105,8 +105,8 @@ class TestTrackService:
         playlist_id = 'playlist-1'
         track_data = {'title': 'New Track'}
         existing_tracks = [
-            {'id': 'track-1', 'number': 1},
-            {'id': 'track-2', 'number': 2}
+            {'id': 'track-1', 'track_number': 1},
+            {'id': 'track-2', 'track_number': 2}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -118,7 +118,7 @@ class TestTrackService:
 
         # Check that track_number is set correctly (should be 3)
         call_args = mock_track_repo.add_to_playlist.call_args[0]
-        assert call_args[1]['number'] == 3
+        assert call_args[1]['track_number'] == 3
 
     @pytest.mark.asyncio
     async def test_update_track_success(self, service, mock_track_repo, mock_playlist_repo):
@@ -172,9 +172,9 @@ class TestTrackService:
         # Per OpenAPI contract v3.3.2: track_ids are filenames
         track_ids = ['file2.mp3', 'file1.mp3', 'file3.mp3']
         existing_tracks = [
-            {'id': 'track-1', 'number': 1, 'filename': 'file1.mp3'},
-            {'id': 'track-2', 'number': 2, 'filename': 'file2.mp3'},
-            {'id': 'track-3', 'number': 3, 'filename': 'file3.mp3'}
+            {'id': 'track-1', 'track_number': 1, 'filename': 'file1.mp3'},
+            {'id': 'track-2', 'track_number': 2, 'filename': 'file2.mp3'},
+            {'id': 'track-3', 'track_number': 3, 'filename': 'file3.mp3'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -200,7 +200,7 @@ class TestTrackService:
         playlist_id = 'playlist-1'
         # Per OpenAPI contract v3.3.2: track_ids are filenames
         track_ids = ['file1.mp3', 'invalid.mp3']
-        existing_tracks = [{'id': 'track-1', 'number': 1, 'filename': 'file1.mp3'}]
+        existing_tracks = [{'id': 'track-1', 'track_number': 1, 'filename': 'file1.mp3'}]
 
         mock_playlist_repo.exists.return_value = True
         mock_track_repo.get_by_playlist.return_value = existing_tracks
@@ -213,8 +213,8 @@ class TestTrackService:
         """Test getting the first track when no current track is specified."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -229,9 +229,9 @@ class TestTrackService:
         """Test getting the next track from the middle of a playlist."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'},
-            {'id': 'track-3', 'number': 3, 'title': 'Track 3'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'},
+            {'id': 'track-3', 'track_number': 3, 'title': 'Track 3'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -246,8 +246,8 @@ class TestTrackService:
         """Test getting the next track when at the end of a playlist."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -262,8 +262,8 @@ class TestTrackService:
         """Test getting the last track when no current track is specified."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -278,9 +278,9 @@ class TestTrackService:
         """Test getting the previous track from the middle of a playlist."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'},
-            {'id': 'track-3', 'number': 3, 'title': 'Track 3'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'},
+            {'id': 'track-3', 'track_number': 3, 'title': 'Track 3'}
         ]
 
         mock_playlist_repo.exists.return_value = True
@@ -295,8 +295,8 @@ class TestTrackService:
         """Test getting the previous track when at the beginning of a playlist."""
         playlist_id = 'playlist-1'
         tracks = [
-            {'id': 'track-1', 'number': 1, 'title': 'Track 1'},
-            {'id': 'track-2', 'number': 2, 'title': 'Track 2'}
+            {'id': 'track-1', 'track_number': 1, 'title': 'Track 1'},
+            {'id': 'track-2', 'track_number': 2, 'title': 'Track 2'}
         ]
 
         mock_playlist_repo.exists.return_value = True

--- a/back/tests/unit/domain/services/test_track_reordering_service.py
+++ b/back/tests/unit/domain/services/test_track_reordering_service.py
@@ -31,10 +31,10 @@ def service():
 def sample_tracks():
     """Create sample tracks for testing."""
     return [
-        Track(number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
-        Track(number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
-        Track(number=3, title="Track 3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
-        Track(number=4, title="Track 4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
+        Track(track_number=1, title="Track 1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
+        Track(track_number=2, title="Track 2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
+        Track(track_number=3, title="Track 3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
+        Track(track_number=4, title="Track 4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
     ]
 
 
@@ -382,9 +382,9 @@ class TestBusinessRuleChecks:
         """Test business rule violation when tracks are missing."""
         # Create reordered list missing a track
         reordered = [
-            Track(number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
-            Track(number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
-            Track(number=3, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
+            Track(track_number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
+            Track(track_number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
+            Track(track_number=3, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
         ]
 
         violations = service._check_business_rules(reordered, sample_tracks)
@@ -396,7 +396,7 @@ class TestBusinessRuleChecks:
         """Test business rule violation when extra tracks added."""
         reordered = service.create_reordered_tracks([4, 3, 2, 1], sample_tracks)
         # Add extra track
-        extra = Track(number=5, title="Extra", filename="e.mp3", file_path="/e.mp3", id="id-extra")
+        extra = Track(track_number=5, title="Extra", filename="e.mp3", file_path="/e.mp3", id="id-extra")
         reordered.append(extra)
 
         violations = service._check_business_rules(reordered, sample_tracks)
@@ -408,10 +408,10 @@ class TestBusinessRuleChecks:
         """Test business rule violation for non-sequential track numbers."""
         # Manually create tracks with gaps in numbering
         reordered = [
-            Track(number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
-            Track(number=3, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),  # Gap!
-            Track(number=4, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
-            Track(number=5, title="T4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
+            Track(track_number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
+            Track(track_number=3, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),  # Gap!
+            Track(track_number=4, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),
+            Track(track_number=5, title="T4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
         ]
 
         violations = service._check_business_rules(reordered, sample_tracks)
@@ -422,10 +422,10 @@ class TestBusinessRuleChecks:
     def test_check_duplicate_track_numbers(self, service, sample_tracks):
         """Test business rule violation for duplicate track numbers."""
         reordered = [
-            Track(number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
-            Track(number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
-            Track(number=2, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),  # Duplicate!
-            Track(number=4, title="T4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
+            Track(track_number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3", id="id1"),
+            Track(track_number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3", id="id2"),
+            Track(track_number=2, title="T3", filename="t3.mp3", file_path="/t3.mp3", id="id3"),  # Duplicate!
+            Track(track_number=4, title="T4", filename="t4.mp3", file_path="/t4.mp3", id="id4"),
         ]
 
         violations = service._check_business_rules(reordered, sample_tracks)
@@ -488,7 +488,7 @@ class TestEdgeCases:
         """Test reordering very large playlist."""
         # Create 100 tracks
         tracks = [
-            Track(number=i, title=f"Track {i}", filename=f"t{i}.mp3",
+            Track(track_number=i, title=f"Track {i}", filename=f"t{i}.mp3",
                   file_path=f"/t{i}.mp3", id=f"id{i}")
             for i in range(1, 101)
         ]
@@ -510,9 +510,9 @@ class TestEdgeCases:
     def test_reorder_tracks_with_metadata(self, service):
         """Test reordering preserves all metadata."""
         tracks = [
-            Track(number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3",
+            Track(track_number=1, title="T1", filename="t1.mp3", file_path="/t1.mp3",
                   duration_ms=180000, artist="Artist 1", album="Album", id="id1"),
-            Track(number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3",
+            Track(track_number=2, title="T2", filename="t2.mp3", file_path="/t2.mp3",
                   duration_ms=240000, artist="Artist 2", album="Album", id="id2"),
         ]
 

--- a/back/tests/unit/infrastructure/test_pure_sqlite_playlist_repository.py
+++ b/back/tests/unit/infrastructure/test_pure_sqlite_playlist_repository.py
@@ -174,7 +174,7 @@ class TestPureSQLitePlaylistRepository:
         """Test that Track objects work with both attribute and dictionary access patterns."""
         track = Track(
             id='track-1',
-            number=1,
+            track_number=1,
             title='Test Track',
             filename='test.mp3',
             file_path='/path/test.mp3',

--- a/back/tests/unit/services/test_broadcasting_contract_validation.py
+++ b/back/tests/unit/services/test_broadcasting_contract_validation.py
@@ -30,16 +30,16 @@ class TestBroadcastingContractValidation:
         """Create broadcasting service instance."""
         return UnifiedBroadcastingService(mock_state_manager)
 
-    def test_validate_and_fix_contract_preserves_existing_number_field(self, broadcasting_service):
-        """Test that validation preserves 'number' field when already present."""
-        # Per OpenAPI contract v3.3.2, tracks have 'number' field directly
+    def test_validate_and_fix_contract_preserves_existing_track_number_field(self, broadcasting_service):
+        """Test that validation preserves 'track_number' field when already present."""
+        # Per OpenAPI contract v4.1.0, tracks have 'track_number' field directly
         valid_playlist = {
             'id': 'test-playlist',
             'title': 'Test Playlist',
             'tracks': [
                 {
                     'id': 'track-1',
-                    'number': 1,  # Per OpenAPI contract v3.3.2
+                    'track_number': 1,  # Per OpenAPI contract v4.1.0
                     'title': 'Test Track',
                     'filename': 'test.mp3',
                     'duration_ms': 180000
@@ -50,11 +50,11 @@ class TestBroadcastingContractValidation:
         # Validate (should not change anything)
         fixed_playlist = broadcasting_service._validate_and_fix_contract(valid_playlist)
 
-        # Verify number is preserved
-        assert 'number' in fixed_playlist['tracks'][0], \
-            "'number' field should be preserved"
-        assert fixed_playlist['tracks'][0]['number'] == 1, \
-            "'number' should have correct value"
+        # Verify track_number is preserved
+        assert 'track_number' in fixed_playlist['tracks'][0], \
+            "'track_number' field should be preserved"
+        assert fixed_playlist['tracks'][0]['track_number'] == 1, \
+            "'track_number' should have correct value"
 
     def test_validate_and_fix_contract_handles_multiple_tracks(self, broadcasting_service):
         """Test validation fixes multiple tracks."""
@@ -62,9 +62,9 @@ class TestBroadcastingContractValidation:
             'id': 'test-playlist',
             'title': 'Test Playlist',
             'tracks': [
-                {'id': 't1', 'number': 1, 'title': 'Track 1', 'filename': 't1.mp3', 'duration_ms': 1000},
-                {'id': 't2', 'number': 2, 'title': 'Track 2', 'filename': 't2.mp3', 'duration_ms': 2000},
-                {'id': 't3', 'number': 3, 'title': 'Track 3', 'filename': 't3.mp3', 'duration_ms': 3000},
+                {'id': 't1', 'track_number': 1, 'title': 'Track 1', 'filename': 't1.mp3', 'duration_ms': 1000},
+                {'id': 't2', 'track_number': 2, 'title': 'Track 2', 'filename': 't2.mp3', 'duration_ms': 2000},
+                {'id': 't3', 'track_number': 3, 'title': 'Track 3', 'filename': 't3.mp3', 'duration_ms': 3000},
             ]
         }
 
@@ -72,8 +72,8 @@ class TestBroadcastingContractValidation:
 
         # All tracks should have 'number' field
         for idx, track in enumerate(fixed_playlist['tracks'], 1):
-            assert 'number' in track, f"Track {idx} missing 'number' field"
-            assert track['number'] == idx, f"Track {idx} has wrong 'number' value"
+            assert 'track_number' in track, f"Track {idx} missing 'number' field"
+            assert track['track_number'] == idx, f"Track {idx} has wrong 'number' value"
 
     def test_validate_and_fix_contract_preserves_correct_tracks(self, broadcasting_service):
         """Test that validation doesn't break correctly serialized tracks."""
@@ -83,7 +83,7 @@ class TestBroadcastingContractValidation:
             'tracks': [
                 {
                     'id': 'track-1',
-                    'number': 1,  # Per OpenAPI contract v3.3.2
+                    'track_number': 1,  # Per OpenAPI contract v3.3.2
                     'title': 'Test Track',
                     'filename': 'test.mp3',
                     'duration_ms': 180000
@@ -94,7 +94,7 @@ class TestBroadcastingContractValidation:
         fixed_playlist = broadcasting_service._validate_and_fix_contract(correct_playlist)
 
         # Should remain unchanged
-        assert fixed_playlist['tracks'][0]['number'] == 1
+        assert fixed_playlist['tracks'][0]['track_number'] == 1
 
     def test_validate_and_fix_contract_preserves_number_field(self, broadcasting_service):
         """Test validation preserves 'number' field as-is (no mismatch possible now)."""
@@ -105,7 +105,7 @@ class TestBroadcastingContractValidation:
             'tracks': [
                 {
                     'id': 'track-1',
-                    'number': 5,
+                    'track_number': 5,
                     'title': 'Test Track',
                     'filename': 'test.mp3',
                     'duration_ms': 180000
@@ -116,7 +116,7 @@ class TestBroadcastingContractValidation:
         fixed_playlist = broadcasting_service._validate_and_fix_contract(valid_playlist)
 
         # 'number' field should be preserved as-is
-        assert fixed_playlist['tracks'][0]['number'] == 5, \
+        assert fixed_playlist['tracks'][0]['track_number'] == 5, \
             "Should preserve 'number' field value"
 
     def test_validate_and_fix_contract_handles_empty_playlist(self, broadcasting_service):
@@ -161,7 +161,7 @@ class TestBroadcastingContractValidation:
             'id': 'test-playlist',
             'title': 'Test Playlist',
             'tracks': [
-                {'id': 't1', 'number': 1, 'title': 'Track 1', 'filename': 't1.mp3', 'duration_ms': 1000}
+                {'id': 't1', 'track_number': 1, 'title': 'Track 1', 'filename': 't1.mp3', 'duration_ms': 1000}
             ]
         }
 
@@ -188,7 +188,7 @@ class TestBroadcastingContractValidation:
             'tracks': [
                 {
                     'id': 'track-1',
-                    'number': 1,  # Per OpenAPI contract v3.3.2
+                    'track_number': 1,  # Per OpenAPI contract v3.3.2
                     'title': 'Test Track',
                     'filename': 'test.mp3',
                     'duration_ms': 180000
@@ -214,7 +214,7 @@ class TestBroadcastingContractValidation:
         if 'playlist' in broadcast_data:
             playlist = broadcast_data['playlist']
             if 'tracks' in playlist and len(playlist['tracks']) > 0:
-                assert 'number' in playlist['tracks'][0], \
+                assert 'track_number' in playlist['tracks'][0], \
                     "Broadcast should include 'number' field"
 
 
@@ -238,7 +238,7 @@ class TestContractValidationLogging:
             'id': 'test-playlist',
             'title': 'Test Playlist',
             'tracks': [
-                {'id': 't1', 'number': 1, 'title': 'Track', 'filename': 'track.mp3', 'duration_ms': 1000}
+                {'id': 't1', 'track_number': 1, 'title': 'Track', 'filename': 'track.mp3', 'duration_ms': 1000}
             ]
         }
 

--- a/back/tests/unit/services/test_filesystem_sync_service.py
+++ b/back/tests/unit/services/test_filesystem_sync_service.py
@@ -223,7 +223,7 @@ class TestFilesystemSyncService:
         existing_playlist = {
             "id": playlist_id,
             "tracks": [
-                {"number": 1, "filename": "existing.mp3", "title": "Existing"}
+                {"track_number": 1, "filename": "existing.mp3", "title": "Existing"}
             ]
         }
         mock_repository.get_playlist_by_id.return_value = existing_playlist
@@ -264,8 +264,8 @@ class TestFilesystemSyncService:
         existing_playlist = {
             "id": playlist_id,
             "tracks": [
-                {"number": 1, "filename": "existing.mp3", "title": "Existing"},
-                {"number": 2, "filename": "removed.mp3", "title": "Removed"}
+                {"track_number": 1, "filename": "existing.mp3", "title": "Existing"},
+                {"track_number": 2, "filename": "removed.mp3", "title": "Removed"}
             ]
         }
         mock_repository.get_playlist_by_id.return_value = existing_playlist

--- a/back/tests/unit/services/test_track_progress_service.py
+++ b/back/tests/unit/services/test_track_progress_service.py
@@ -461,7 +461,7 @@ class TestTrackProgressServiceTrackChange:
         service = TrackProgressService(state_manager, coordinator)
 
         status = {
-            "number": 1,
+            "track_number": 1,
             "active_track_id": "track-123"
         }
 
@@ -485,7 +485,7 @@ class TestTrackProgressServiceTrackChange:
 
         # Change to new track
         status = {
-            "number": 2,
+            "track_number": 2,
             "active_track_id": "track-456"
         }
 
@@ -509,7 +509,7 @@ class TestTrackProgressServiceTrackChange:
 
         # Same track
         status = {
-            "number": 1,
+            "track_number": 1,
             "active_track_id": "track-123"
         }
 

--- a/back/tests/unit/services/test_unified_serialization_service.py
+++ b/back/tests/unit/services/test_unified_serialization_service.py
@@ -29,7 +29,7 @@ class TestTrackSerialization:
         """
         track = Track(
             id="test-track-id",
-            number=5,
+            track_number=5,
             title="Test Track",
             filename="test.mp3",
             file_path="/path/to/test.mp3",
@@ -44,11 +44,11 @@ class TestTrackSerialization:
         )
 
         # CRITICAL: Verify 'number' field exists (per OpenAPI contract v3.3.2)
-        assert "number" in result, (
+        assert "track_number" in result, (
             f"Track serialization missing 'number' field. "
             f"Available fields: {list(result.keys())}"
         )
-        assert result["number"] == 5, "number field should match track position"
+        assert result["track_number"] == 5, "number field should match track position"
 
         # Per OpenAPI contract v3.3.2, 'number' field should exist (no track_number mapping needed)
 
@@ -56,7 +56,7 @@ class TestTrackSerialization:
         """Verify all required fields are present in API format."""
         track = Track(
             id="test-id",
-            number=3,
+            track_number=3,
             title="Track Title",
             filename="track.mp3",
             file_path="/path/track.mp3",
@@ -71,7 +71,7 @@ class TestTrackSerialization:
         # Required fields per OpenAPI contract v3.3.2 and frontend Track interface
         required_fields = [
             "id",
-            "number",  # Per OpenAPI contract v3.3.2
+            "track_number",  # Per OpenAPI contract v3.3.2
             "title",
             "filename",
             "duration_ms",
@@ -88,12 +88,12 @@ class TestTrackSerialization:
         """
         Verify track_number is never 0 in serialization.
 
-        In issue #71, all tracks had number=0 due to missing field,
+        In issue #71, all tracks had track_number=0 due to missing field,
         causing deletion to remove all tracks.
         """
         track = Track(
             id="test-id",
-            number=1,
+            track_number=1,
             title="First Track",
             filename="first.mp3",
             file_path="/path/first.mp3"
@@ -104,13 +104,13 @@ class TestTrackSerialization:
             format=UnifiedSerializationService.FORMAT_API
         )
 
-        assert result["number"] > 0, "Track number should never be 0 for valid tracks"
+        assert result["track_number"] > 0, "Track number should never be 0 for valid tracks"
 
     def test_serialize_track_websocket_format(self):
         """Verify WebSocket format is minimal and compact."""
         track = Track(
             id="test-id",
-            number=2,
+            track_number=2,
             title="Track 2",
             filename="track2.mp3",
             file_path="/path/track2.mp3",
@@ -123,14 +123,14 @@ class TestTrackSerialization:
         )
 
         # WebSocket format should be minimal (per OpenAPI contract v3.3.2)
-        expected_fields = {"id", "number", "title", "duration_ms"}
+        expected_fields = {"id", "track_number", "title", "duration_ms"}
         assert set(result.keys()) == expected_fields
 
     def test_serialize_track_from_dict(self):
         """Verify serialization works with dict input (repository layer)."""
         track_dict = {
             "id": "dict-track-id",
-            "number": 7,
+            "track_number": 7,
             "title": "Dict Track",
             "filename": "dict.mp3",
             "file_path": "/path/dict.mp3",
@@ -142,8 +142,8 @@ class TestTrackSerialization:
             format=UnifiedSerializationService.FORMAT_API
         )
 
-        assert "number" in result
-        assert result["number"] == 7
+        assert "track_number" in result
+        assert result["track_number"] == 7
 
 
 class TestPlaylistSerialization:
@@ -153,14 +153,14 @@ class TestPlaylistSerialization:
         """Verify tracks in playlist have 'number' field."""
         track1 = Track(
             id="track-1",
-            number=1,
+            track_number=1,
             title="Track 1",
             filename="track1.mp3",
             file_path="/path/track1.mp3"
         )
         track2 = Track(
             id="track-2",
-            number=2,
+            track_number=2,
             title="Track 2",
             filename="track2.mp3",
             file_path="/path/track2.mp3"
@@ -182,17 +182,17 @@ class TestPlaylistSerialization:
         # Verify all tracks have 'number' field
         assert len(result["tracks"]) == 2
         for track in result["tracks"]:
-            assert "number" in track, (
+            assert "track_number" in track, (
                 f"Track in playlist missing 'number' field: {track.keys()}"
             )
-            assert track["number"] > 0
+            assert track["track_number"] > 0
 
     def test_serialize_playlist_track_numbers_are_sequential(self):
         """Verify track numbers are preserved correctly."""
         tracks = [
             Track(
                 id=f"track-{i}",
-                number=i,
+                track_number=i,
                 title=f"Track {i}",
                 filename=f"track{i}.mp3",
                 file_path=f"/path/track{i}.mp3"
@@ -214,7 +214,7 @@ class TestPlaylistSerialization:
         )
 
         # Verify track numbers are 1, 2, 3, 4, 5
-        track_numbers = [track["number"] for track in result["tracks"]]
+        track_numbers = [track["track_number"] for track in result["tracks"]]
         assert track_numbers == [1, 2, 3, 4, 5]
 
 
@@ -239,7 +239,7 @@ class TestContractCompliance:
         """
         track = Track(
             id="contract-test-id",
-            number=10,
+            track_number=10,
             title="Contract Test",
             filename="contract.mp3",
             file_path="/path/contract.mp3",
@@ -253,13 +253,13 @@ class TestContractCompliance:
 
         # Frontend contract requirements
         assert isinstance(result["id"], str)
-        assert isinstance(result["number"], int)  # Frontend expects 'number'
+        assert isinstance(result["track_number"], int)  # Frontend expects 'number'
         assert isinstance(result["title"], str)
         assert isinstance(result["filename"], str)
         assert isinstance(result["duration_ms"], int)
 
         # Track number must be valid (> 0)
-        assert result["number"] > 0
+        assert result["track_number"] > 0
 
     def test_no_silent_defaults_in_serialization(self):
         """
@@ -270,7 +270,7 @@ class TestContractCompliance:
         """
         track = Track(
             id="explicit-test",
-            number=15,
+            track_number=15,
             title="Explicit Values",
             filename="explicit.mp3",
             file_path="/path/explicit.mp3"
@@ -282,7 +282,7 @@ class TestContractCompliance:
         )
 
         # Critical fields must have explicit values, not None or 0
-        assert result["number"] is not None
-        assert result["number"] != 0
-        assert result["number"] is not None
-        assert result["number"] != 0
+        assert result["track_number"] is not None
+        assert result["track_number"] != 0
+        assert result["track_number"] is not None
+        assert result["track_number"] != 0

--- a/back/tests/unit/services/test_unified_validation_service.py
+++ b/back/tests/unit/services/test_unified_validation_service.py
@@ -108,7 +108,7 @@ class TestValidateTrackData:
         data = {
             "title": "Song Title",
             "filename": "song.mp3",
-            "number": 1,
+            "track_number": 1,
             "duration_ms": 180000,
         }
         is_valid, errors = UnifiedValidationService.validate_track_data(
@@ -119,7 +119,7 @@ class TestValidateTrackData:
 
     def test_missing_title(self):
         """Test validation fails without title."""
-        data = {"filename": "song.mp3", "number": 1}
+        data = {"filename": "song.mp3", "track_number": 1}
         is_valid, errors = UnifiedValidationService.validate_track_data(
             data, context="api", validate_file_exists=False
         )
@@ -137,7 +137,7 @@ class TestValidateTrackData:
 
     def test_invalid_track_number(self):
         """Test validation fails with invalid track number."""
-        data = {"title": "Song", "number": -1}
+        data = {"title": "Song", "track_number": -1}
         is_valid, errors = UnifiedValidationService.validate_track_data(
             data, context="api", validate_file_exists=False
         )
@@ -146,7 +146,7 @@ class TestValidateTrackData:
 
     def test_track_number_too_high(self):
         """Test validation fails with track number too high."""
-        data = {"title": "Song", "number": 10000}
+        data = {"title": "Song", "track_number": 10000}
         is_valid, errors = UnifiedValidationService.validate_track_data(
             data, context="api", validate_file_exists=False
         )

--- a/back/tests/unit/test_serialization_contracts.py
+++ b/back/tests/unit/test_serialization_contracts.py
@@ -25,7 +25,7 @@ class TestSerializationContracts:
     def sample_track(self):
         """Create a sample track for testing."""
         return Track(
-            number=1,
+            track_number=1,
             title="Test Track",
             filename="test.mp3",
             file_path="/test/test.mp3",
@@ -50,10 +50,10 @@ class TestSerializationContracts:
         """Test that track serialization includes ALL required fields for frontend contract."""
         result = UnifiedSerializationService.serialize_track(sample_track, format="api")
 
-        # Required fields per OpenAPI contract v3.3.2
+        # Required fields per OpenAPI contract v4.1.0
         required_fields = [
             'id',
-            'number',  # Per OpenAPI contract v3.3.2 - CRITICAL
+            'track_number',  # Per OpenAPI contract v4.1.0 - CRITICAL
             'title',
             'filename',
             'file_path',
@@ -64,7 +64,7 @@ class TestSerializationContracts:
             assert field in result, f"Missing required field: {field}"
 
         # Per OpenAPI contract v3.3.2, 'number' field should exist (no mapping needed)
-        assert result['number'] == 1, "Expected track number 1"
+        assert result['track_number'] == 1, "Expected track number 1"
 
     def test_track_serialization_field_types(self, sample_track):
         """Test that serialized track fields have correct types."""
@@ -72,7 +72,7 @@ class TestSerializationContracts:
 
         # Type validation per OpenAPI contract v3.3.2
         assert isinstance(result['id'], str), "id must be string"
-        assert isinstance(result['number'], int), "number must be integer"
+        assert isinstance(result['track_number'], int), "number must be integer"
         assert isinstance(result['title'], str), "title must be string"
         assert isinstance(result['filename'], str), "filename must be string"
         assert isinstance(result['duration_ms'], int), "duration_ms must be integer"
@@ -83,11 +83,11 @@ class TestSerializationContracts:
 
         # The 'number' field is a @property on Track model
         # It should be explicitly added by serialization service
-        assert 'number' in result, \
+        assert 'track_number' in result, \
             "Serialization MUST include @property field 'number' for frontend compatibility"
 
         # Verify it returns the correct value
-        assert result['number'] == sample_track.number, \
+        assert result['track_number'] == sample_track.number, \
             "Serialized 'number' must match Track.number property"
 
     def test_playlist_serialization_includes_tracks_with_number_field(self, sample_playlist):
@@ -99,24 +99,24 @@ class TestSerializationContracts:
 
         # Verify each track has the 'number' field
         for track in result['tracks']:
-            assert 'number' in track, \
+            assert 'track_number' in track, \
                 f"Track '{track.get('title')}' missing 'number' field in playlist serialization"
-            assert isinstance(track['number'], int), \
-                f"Track 'number' field must be integer, got {type(track['number'])}"
+            assert isinstance(track['track_number'], int), \
+                f"Track 'number' field must be integer, got {type(track['track_number'])}"
 
     def test_track_serialization_consistency_across_formats(self, sample_track):
         """Test that different serialization formats maintain 'number' field."""
         api_result = UnifiedSerializationService.serialize_track(sample_track, format="api")
 
         # API format MUST include 'number' field
-        assert 'number' in api_result, "API format must include 'number' field"
-        assert api_result['number'] == 1
+        assert 'track_number' in api_result, "API format must include 'number' field"
+        assert api_result['track_number'] == 1
 
     def test_track_serialization_from_dict(self):
         """Test that serialization works when input is already a dict."""
         track_dict = {
             'id': 'test-id',
-            'number': 5,
+            'track_number': 5,  # OpenAPI contract v4.1.0
             'title': 'Dict Track',
             'filename': 'track.mp3',
             'file_path': '/path/track.mp3',
@@ -125,13 +125,13 @@ class TestSerializationContracts:
 
         result = UnifiedSerializationService.serialize_track(track_dict, format="api")
 
-        assert 'number' in result, "Must add 'number' field even when serializing from dict"
-        assert result['number'] == 5, "number should match track_number from dict"
+        assert 'track_number' in result, "Must add 'track_number' field even when serializing from dict"
+        assert result['track_number'] == 5, "track_number should match input dict"
 
     def test_track_serialization_handles_missing_optional_fields(self):
         """Test that serialization handles tracks with missing optional fields gracefully."""
         minimal_track = Track(
-            number=1,
+            track_number=1,
             title="Minimal Track",
             filename="minimal.mp3",
             file_path="/minimal.mp3",
@@ -143,8 +143,8 @@ class TestSerializationContracts:
         result = UnifiedSerializationService.serialize_track(minimal_track, format="api")
 
         # Still must have required fields
-        assert 'number' in result, "Must include 'number' even for minimal track"
-        assert result['number'] == 1
+        assert 'track_number' in result, "Must include 'number' even for minimal track"
+        assert result['track_number'] == 1
 
     def test_serialization_prevents_silent_field_omission(self, sample_track):
         """Test that serialization explicitly includes fields, not relying on @property auto-serialization."""
@@ -154,7 +154,7 @@ class TestSerializationContracts:
         # Python's dataclasses.asdict() does NOT serialize @property fields
         # UnifiedSerializationService MUST explicitly add them
 
-        assert 'number' in result, \
+        assert 'track_number' in result, \
             "REGRESSION CHECK: 'number' field must be present " \
             "(Track entity now uses 'number' directly per OpenAPI contract v3.3.2)"
 
@@ -166,12 +166,12 @@ class TestSerializationContracts:
         # This test ensures it never happens again
 
         for idx, track in enumerate(result['tracks']):
-            assert 'number' in track, \
+            assert 'track_number' in track, \
                 f"REGRESSION: Track {idx} in playlist missing 'number' field. " \
                 f"This caused issue #71 where playlists with NFC tags failed to display."
 
             # Per OpenAPI contract v3.3.2, 'number' field must exist
-            assert 'number' in track, \
+            assert 'track_number' in track, \
                 f"Track {idx} must have 'number' field per OpenAPI contract v3.3.2"
 
 
@@ -182,7 +182,7 @@ class TestSerializationContractValidation:
         """Test validation passes for correctly serialized track."""
         valid_track = {
             'id': 'test-id',
-            'number': 1,
+            'track_number': 1,  # OpenAPI contract v4.1.0
             'title': 'Valid Track',
             'filename': 'valid.mp3',
             'file_path': '/valid.mp3',
@@ -190,9 +190,9 @@ class TestSerializationContractValidation:
         }
 
         # Should not raise any assertions
-        assert 'number' in valid_track
-        # Valid track now only has 'number' per OpenAPI contract v3.3.2
-        assert valid_track['number'] == 1
+        assert 'track_number' in valid_track
+        # Valid track now only has 'track_number' per OpenAPI contract v4.1.0
+        assert valid_track['track_number'] == 1
 
     def test_validate_track_dict_detects_missing_number_field(self):
         """Test that we can detect missing 'number' field (the bug from issue #71)."""
@@ -210,14 +210,14 @@ class TestSerializationContractValidation:
             "This test documents the bug: 'number' field was missing"
 
         # Validation should detect this
-        has_number = 'number' in buggy_track_without_number
+        has_number = 'track_number' in buggy_track_without_number
         assert not has_number, "Test confirms the field is missing"
 
     def test_all_serialization_paths_produce_identical_output(self):
         """Test that different serialization paths produce consistent output."""
         # Create test track
         track = Track(
-            number=7,
+            track_number=7,
             title="Consistency Test",
             filename="test.mp3",
             file_path="/test.mp3",
@@ -229,10 +229,10 @@ class TestSerializationContractValidation:
         unified_result = UnifiedSerializationService.serialize_track(track, format="api")
 
         # Key fields should be present per OpenAPI contract v3.3.2
-        assert unified_result['number'] == 7
+        assert unified_result['track_number'] == 7
         assert unified_result['title'] == "Consistency Test"
         # Per OpenAPI contract v3.3.2, 'number' field must exist
-        assert 'number' in unified_result
+        assert 'track_number' in unified_result
 
         # Note: We removed the buggy PurePlaylistRepositoryAdapter._track_to_dict()
         # so there's now only ONE serialization path - which prevents divergence!
@@ -244,7 +244,7 @@ class TestContractRegressionPrevention:
     def test_track_number_field_always_present_in_api_format(self):
         """Critical test: 'number' field MUST be present in API format."""
         track = Track(
-            number=99,
+            track_number=99,
             title="Critical Test",
             filename="critical.mp3",
             file_path="/critical.mp3",
@@ -254,10 +254,10 @@ class TestContractRegressionPrevention:
 
         result = UnifiedSerializationService.serialize_track(track, format="api")
 
-        assert 'number' in result, \
+        assert 'track_number' in result, \
             "CRITICAL: 'number' field missing. This causes frontend contract violations!"
 
-        assert result['number'] == 99, \
+        assert result['track_number'] == 99, \
             "'number' field has wrong value"
 
     def test_websocket_broadcast_data_includes_number_field(self):
@@ -267,7 +267,7 @@ class TestContractRegressionPrevention:
             title="WebSocket Test",
             tracks=[
                 Track(
-                    number=1,
+                    track_number=1,
                     title="WS Track",
                     filename="ws.mp3",
                     file_path="/ws.mp3",
@@ -284,7 +284,7 @@ class TestContractRegressionPrevention:
         # The bug in issue #71: WebSocket broadcasts used PurePlaylistRepositoryAdapter._track_to_dict()
         # which didn't include 'number' field
         assert len(result['tracks']) > 0
-        assert 'number' in result['tracks'][0], \
+        assert 'track_number' in result['tracks'][0], \
             "WebSocket broadcasts MUST include 'number' field (issue #71 regression check)"
 
     def test_nfc_triggered_playlist_load_includes_number_field(self):
@@ -298,7 +298,7 @@ class TestContractRegressionPrevention:
             nfc_tag_id="04889462251c91",
             tracks=[
                 Track(
-                    number=1,
+                    track_number=1,
                     title="A la volette [zV-Rl7VVagw]",
                     filename="track.mp3",
                     file_path="/track.mp3",
@@ -313,7 +313,7 @@ class TestContractRegressionPrevention:
 
         # This was the exact error message from issue #71
         track = result['tracks'][0]
-        assert 'number' in track, \
+        assert 'track_number' in track, \
             f"CONTRACT VIOLATION: Track missing required 'number' field. " \
             f"Track: {track.get('title')} (ID: {track.get('id')}). " \
             f"Available fields: {', '.join(track.keys())}. " \

--- a/front/src/components/files/FilesList.vue
+++ b/front/src/components/files/FilesList.vue
@@ -645,7 +645,7 @@ async function processDragEvent(evt: { moved?: { element: Track }; added?: { ele
         playlistId,
         trackCount: currentPlaylist.tracks.length,
         newOrder: trackNumbers,
-        firstThreeTracks: currentPlaylist.tracks.slice(0, 3).map(t => ({ number: getTrackNumber(t), title: t.title }))
+        firstThreeTracks: currentPlaylist.tracks.slice(0, 3).map(t => ({ track_number: getTrackNumber(t), title: t.title }))
       }, 'FilesList')
 
       // reorderTracks handles optimistic update internally

--- a/front/src/stores/unifiedPlaylistStore.ts
+++ b/front/src/stores/unifiedPlaylistStore.ts
@@ -333,7 +333,7 @@ export const useUnifiedPlaylistStore = defineStore('unifiedPlaylist', () => {
         trackNumbers: playlistTracks?.map(t => getTrackNumber(t)) || [],
         trackData: playlistTracks?.map(t => ({
           filename: t.filename,
-          number: t.number,
+          track_number: getTrackNumber(t),
           allKeys: Object.keys(t),
           rawTrack: t
         })) || []
@@ -462,7 +462,7 @@ export const useUnifiedPlaylistStore = defineStore('unifiedPlaylist', () => {
         .filter((track): track is Track => track !== undefined)
         .map((track, index) => ({
           ...track,
-          number: index + 1 // Update track numbers for new positions (v3.3.2 uses 'number')
+          track_number: index + 1 // Update track numbers for new positions (v4.1.0 uses 'track_number')
         }))
 
       tracks.value.set(playlistId, reorderedTracks)
@@ -640,7 +640,7 @@ export const useUnifiedPlaylistStore = defineStore('unifiedPlaylist', () => {
           playlistId: playlist.id,
           tracksCount: sortedTracks.length,
           firstTrackNumber: sortedTracks[0] ? getTrackNumber(sortedTracks[0]) : 0,
-          trackTitles: sortedTracks.slice(0, 3).map((t: any) => ({ number: getTrackNumber(t), title: t.title, filename: t.filename }))
+          trackTitles: sortedTracks.slice(0, 3).map((t: any) => ({ track_number: getTrackNumber(t), title: t.title, filename: t.filename }))
         })
       }
     }

--- a/front/src/tests/contracts/schemas/api_contracts.json
+++ b/front/src/tests/contracts/schemas/api_contracts.json
@@ -715,7 +715,7 @@
     "Track": {
       "type": "object",
       "properties": {
-        "number": {"type": "integer"},
+        "track_number": {"type": "integer"},
         "title": {"type": "string"},
         "filename": {"type": "string"},
         "file_path": {"type": "string"},
@@ -727,7 +727,7 @@
         "created_at": {"type": "string"},
         "updated_at": {"type": "string"}
       },
-      "required": ["number", "title", "filename"]
+      "required": ["track_number", "title", "filename"]
     },
     "PlayerState": {
       "type": "object",

--- a/front/src/tests/contracts/schemas/socketio_contracts.json
+++ b/front/src/tests/contracts/schemas/socketio_contracts.json
@@ -239,7 +239,7 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "number": {"type": "integer"},
+                    "track_number": {"type": "integer"},
                     "title": {"type": "string"},
                     "filename": {"type": "string"},
                     "duration": {"type": ["integer", "null"]},
@@ -247,7 +247,7 @@
                     "artist": {"type": ["string", "null"]},
                     "album": {"type": ["string", "null"]}
                   },
-                  "required": ["number", "title", "filename"]
+                  "required": ["track_number", "title", "filename"]
                 }
               },
               "nfc_tag_id": {"type": ["string", "null"]},
@@ -265,14 +265,14 @@
           "data_schema": {
             "type": "object",
             "properties": {
-              "number": {"type": "integer"},
+              "track_number": {"type": "integer"},
               "title": {"type": "string"},
               "filename": {"type": "string"},
               "duration": {"type": ["integer", "null"]},
               "duration_ms": {"type": ["integer", "null"]},
               "playlist_id": {"type": "string"}
             },
-            "required": ["number", "title", "filename", "playlist_id"]
+            "required": ["track_number", "title", "filename", "playlist_id"]
           },
           "description": "Track-level changes",
           "frequency": "on_demand"
@@ -363,13 +363,13 @@
               "track": {
                 "type": "object",
                 "properties": {
-                  "number": {"type": "integer"},
+                  "track_number": {"type": "integer"},
                   "title": {"type": "string"},
                   "filename": {"type": "string"},
                   "duration": {"type": ["integer", "null"]},
                   "duration_ms": {"type": ["integer", "null"]}
                 },
-                "required": ["number", "title", "filename"]
+                "required": ["track_number", "title", "filename"]
               }
             },
             "required": ["playlist_id", "track"]
@@ -606,7 +606,7 @@
               "track": {
                 "type": "object",
                 "properties": {
-                  "number": {"type": "integer"},
+                  "track_number": {"type": "integer"},
                   "title": {"type": "string"},
                   "filename": {"type": "string"},
                   "duration": {"type": ["integer", "null"]},

--- a/front/src/tests/unit/stores/unifiedPlaylistStore.test.ts
+++ b/front/src/tests/unit/stores/unifiedPlaylistStore.test.ts
@@ -359,23 +359,23 @@ describe('unifiedPlaylistStore', () => {
       const updatedTracks = store.getTracksForPlaylist('pl1')
       expect(updatedTracks).toHaveLength(5)
 
-      // Track 5 should now be first with number = 1
+      // Track 5 should now be first with track_number = 1 (v4.1.0)
       expect(updatedTracks[0].id).toBe('t5')
-      expect(updatedTracks[0].number).toBe(1)
+      expect(updatedTracks[0].track_number).toBe(1)
       expect(updatedTracks[0].title).toBe('Track 5')
 
-      // Track 1 should now be second with number = 2
+      // Track 1 should now be second with track_number = 2
       expect(updatedTracks[1].id).toBe('t1')
-      expect(updatedTracks[1].number).toBe(2)
+      expect(updatedTracks[1].track_number).toBe(2)
       expect(updatedTracks[1].title).toBe('Track 1')
 
       // Verify all tracks are in correct order
       expect(updatedTracks[2].id).toBe('t2')
-      expect(updatedTracks[2].number).toBe(3)
+      expect(updatedTracks[2].track_number).toBe(3)
       expect(updatedTracks[3].id).toBe('t3')
-      expect(updatedTracks[3].number).toBe(4)
+      expect(updatedTracks[3].track_number).toBe(4)
       expect(updatedTracks[4].id).toBe('t4')
-      expect(updatedTracks[4].number).toBe(5)
+      expect(updatedTracks[4].track_number).toBe(5)
     })
 
     it('should move track between playlists', async () => {

--- a/front/src/tests/unit/utils/trackFieldAccessor.test.ts
+++ b/front/src/tests/unit/utils/trackFieldAccessor.test.ts
@@ -78,7 +78,7 @@ describe('trackFieldAccessor', () => {
       }
 
       expect(() => getTrackNumber(track as any))
-        .toThrow('Track missing required \'number\' field')
+        .toThrow('Track missing required \'track_number\' field')
     })
 
     it('should throw on null number values (fail-loud)', () => {
@@ -87,7 +87,7 @@ describe('trackFieldAccessor', () => {
       }
 
       expect(() => getTrackNumber(track as any))
-        .toThrow('Track missing required \'number\' field')
+        .toThrow('Track missing required \'track_number\' field')
     })
 
     it('should handle zero values correctly', () => {
@@ -105,7 +105,7 @@ describe('trackFieldAccessor', () => {
       expect(() => getTrackNumber(undefined as any))
         .toThrow('Track is null or undefined')
       expect(() => getTrackNumber({} as any))
-        .toThrow('Track missing required \'number\' field')
+        .toThrow('Track missing required \'track_number\' field')
     })
   })
 
@@ -409,7 +409,7 @@ describe('trackFieldAccessor', () => {
 
       // Fail-loud: invalid tracks cause immediate errors
       expect(() => findTrackByNumber(tracksWithoutNumbers as any, 1))
-        .toThrow('Track missing required \'number\' field')
+        .toThrow('Track missing required \'track_number\' field')
     })
   })
 
@@ -468,7 +468,7 @@ describe('trackFieldAccessor', () => {
 
       // Fail-loud: invalid tracks cause immediate errors during sort
       expect(() => sortTracksByNumber(tracks as any))
-        .toThrow('Track missing required \'number\' field')
+        .toThrow('Track missing required \'track_number\' field')
     })
 
     it('should handle empty array', () => {
@@ -786,7 +786,7 @@ describe('trackFieldAccessor', () => {
   })
 
   describe('batchUpdateTrackNumbers', () => {
-    it('should update track numbers correctly (v3.3.2 uses number field)', () => {
+    it('should update track numbers correctly (v4.1.0 uses track_number field)', () => {
       const tracks: MockTrack[] = [
         { id: '1', number: 3, title: 'Track A' },
         { id: '2', number: 1, title: 'Track B' },
@@ -799,11 +799,11 @@ describe('trackFieldAccessor', () => {
 
       expect(updated)
         .toHaveLength(3)
-      expect(updated[0].number)
+      expect(updated[0].track_number)
         .toBe(1)
-      expect(updated[1].number)
+      expect(updated[1].track_number)
         .toBe(2)
-      expect(updated[2].number)
+      expect(updated[2].track_number)
         .toBe(3)
     })
 
@@ -821,7 +821,7 @@ describe('trackFieldAccessor', () => {
         .toBe('Track A')
       expect(updated[0].artist)
         .toBe('Artist 1')
-      expect(updated[0].number)
+      expect(updated[0].track_number)
         .toBe(1)
       expect(updated[1].id)
         .toBe('2')
@@ -829,7 +829,7 @@ describe('trackFieldAccessor', () => {
         .toBe('Track B')
       expect(updated[1].artist)
         .toBe('Artist 2')
-      expect(updated[1].number)
+      expect(updated[1].track_number)
         .toBe(2)
     })
 
@@ -859,7 +859,7 @@ describe('trackFieldAccessor', () => {
 
       const updated = batchUpdateTrackNumbers(tracks as any, [1])
 
-      expect(updated[0].number)
+      expect(updated[0].track_number)
         .toBe(1)
     })
   })

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,12 +1,12 @@
 /**
  * Frontend Types - Central Export Point
  *
- * Uses ONLY generated types from OpenAPI Contract v4.0.0
+ * Uses ONLY generated types from OpenAPI Contract v4.1.0
  * Zero legacy code - 100% contract-driven development
  */
 
-// Import generated types from contracts v4.0.0
-import type { components } from '../../../contracts/releases/4.0.0-d18d3f2/typescript/api-types';
+// Import generated types from contracts v4.1.0
+import type { components } from '../../../contracts/releases/4.1.0-7dc3483/typescript/api-types';
 
 // Export core data types from OpenAPI schema
 export type Track = components['schemas']['Track'];

--- a/front/src/types/socket.ts
+++ b/front/src/types/socket.ts
@@ -59,7 +59,7 @@ export interface PlaylistStateData {
   id: string;
   title: string;
   tracks?: Array<{
-    number: number;
+    track_number: number;  // OpenAPI v4.1.0
     title: string;
     filename: string;
     duration?: number;

--- a/front/src/unit/stores/unifiedPlaylistStore.test.ts
+++ b/front/src/unit/stores/unifiedPlaylistStore.test.ts
@@ -103,12 +103,12 @@ describe('unifiedPlaylistStore', () => {
     // deleteTrack updates track_count
     api.deleteTrack.mockResolvedValue({})
     await store.deleteTrack('p1', 1)
-    expect(store.getTracksForPlaylist('p1').some(t => t.number === 1)).toBe(false)
+    expect(store.getTracksForPlaylist('p1').some(t => t.track_number === 1)).toBe(false)
 
-    // reorderTracks - store uses 'number' field for optimistic update
+    // reorderTracks - store uses 'track_number' field for optimistic update (v4.1.0)
     api.reorderTracks.mockResolvedValue({})
     await store.reorderTracks('p1', [2])
-    expect(store.getTracksForPlaylist('p1')[0].number).toBe(1)
+    expect(store.getTracksForPlaylist('p1')[0].track_number).toBe(1)
   })
 
   it('websocket handlers cover branches', async () => {
@@ -377,20 +377,20 @@ describe('unifiedPlaylistStore', () => {
     const store = useUnifiedPlaylistStore()
     const api = (await import('@/services/apiService')).default as any
     const tracksData = [
-      { id: 'track-1', number: 1, title: 'Track 1', filename: 'track1.mp3' },
-      { id: 'track-2', number: 2, title: 'Track 2', filename: 'track2.mp3' }
+      { id: 'track-1', track_number: 1, title: 'Track 1', filename: 'track1.mp3' },
+      { id: 'track-2', track_number: 2, title: 'Track 2', filename: 'track2.mp3' }
     ]
     api.getPlaylists.mockResolvedValue([{ id: 'p1', title: 'A', tracks: tracksData }])
     await store.loadAllPlaylists()
     // build index map via loadPlaylistTracks path
     api.getPlaylist.mockResolvedValue({ id: 'p1', title: 'A', tracks: tracksData })
     await store.loadPlaylistTracks('p1')
-    expect(store.getTrackByNumberOptimized('p1', 2)!.number).toBe(2)
+    expect(store.getTrackByNumberOptimized('p1', 2)!.track_number).toBe(2)
 
-    // reorder success - store uses 'number' field for optimistic update
+    // reorder success - store uses 'track_number' field for optimistic update (v4.1.0)
     api.reorderTracks.mockResolvedValueOnce({})
     await store.reorderTracks('p1', [2, 1])
-    expect(store.getTracksForPlaylist('p1')[0].number).toBe(1)
+    expect(store.getTracksForPlaylist('p1')[0].track_number).toBe(1)
 
     // reorder with unknown track number (filters undefined entries)
     api.reorderTracks.mockResolvedValueOnce({})

--- a/front/src/unit/utils/trackFieldAccessor.test.ts
+++ b/front/src/unit/utils/trackFieldAccessor.test.ts
@@ -107,8 +107,8 @@ describe('trackFieldAccessor', () => {
 
     const arr = [t({ number: 5 }), t({ number: 9 })]
     const updated = batchUpdateTrackNumbers(arr as any, [1, 2])
-    expect(updated[0].number).toBe(1)
-    expect(updated[1].number).toBe(2)
+    expect(updated[0].track_number).toBe(1)
+    expect(updated[1].track_number).toBe(2)
 
     expect(() => batchUpdateTrackNumbers([t({})] as any, [1,2])).toThrow(/Track count mismatch/)
   })

--- a/front/src/utils/trackFieldAccessor.ts
+++ b/front/src/utils/trackFieldAccessor.ts
@@ -2,18 +2,20 @@
  * Track Field Accessor Utilities
  *
  * Centralized utilities for accessing track fields safely.
- * Uses ONLY OpenAPI Contract v3.3.2 types.
+ * Uses ONLY OpenAPI Contract v4.1.0 types.
  */
 
 import type { Track } from '@/types'
 import { logger } from './logger'
 
 /**
- * Get track number from contract v3.3.2
+ * Get track number from contract v4.1.0
  *
  * IMPORTANT: No longer uses silent fallback to 0.
- * Logs error and throws if 'number' field is missing to prevent
+ * Logs error and throws if 'track_number' field is missing to prevent
  * contract violations from causing silent data corruption (issue #71).
+ *
+ * Supports backward compatibility with legacy 'number' field during migration.
  */
 export function getTrackNumber(track: Track): number {
   if (!track) {
@@ -21,11 +23,13 @@ export function getTrackNumber(track: Track): number {
     throw new Error('Track is null or undefined')
   }
 
-  // Check if 'number' field exists (contract requirement)
-  if (track.number === undefined || track.number === null) {
+  // Check for 'track_number' field (v4.1.0 contract), fallback to 'number' for backward compat
+  const trackNumber = track.track_number ?? (track as any).number
+
+  if (trackNumber === undefined || trackNumber === null) {
     const trackKeys = Object.keys(track)
     logger.error(
-      'CONTRACT VIOLATION: Track missing required "number" field',
+      'CONTRACT VIOLATION: Track missing required "track_number" field',
       {
         trackId: (track as any).id,
         trackTitle: track.title,
@@ -37,45 +41,45 @@ export function getTrackNumber(track: Track): number {
     )
 
     throw new Error(
-      `Track missing required 'number' field. ` +
+      `Track missing required 'track_number' field. ` +
       `Available fields: ${trackKeys.join(', ')}. ` +
       `This indicates a backend serialization bug (see issue #71).`
     )
   }
 
-  // Validate number is actually a number type
-  if (typeof track.number !== 'number') {
+  // Validate track_number is actually a number type
+  if (typeof trackNumber !== 'number') {
     logger.error(
-      'CONTRACT VIOLATION: Track "number" field has wrong type',
+      'CONTRACT VIOLATION: Track "track_number" field has wrong type',
       {
-        trackNumber: track.number,
-        actualType: typeof track.number,
+        trackNumber: trackNumber,
+        actualType: typeof trackNumber,
         trackId: (track as any).id
       },
       'trackFieldAccessor'
     )
 
     throw new Error(
-      `Track 'number' field has wrong type. ` +
-      `Expected: number, Got: ${typeof track.number}. ` +
-      `Value: ${track.number}`
+      `Track 'track_number' field has wrong type. ` +
+      `Expected: number, Got: ${typeof trackNumber}. ` +
+      `Value: ${trackNumber}`
     )
   }
 
-  // Validate number is positive
-  if (track.number <= 0) {
+  // Validate track_number is positive
+  if (trackNumber <= 0) {
     logger.warn(
-      'Track has invalid number (<=0)',
-      { trackNumber: track.number, trackId: (track as any).id },
+      'Track has invalid track_number (<=0)',
+      { trackNumber: trackNumber, trackId: (track as any).id },
       'trackFieldAccessor'
     )
   }
 
-  return track.number
+  return trackNumber
 }
 
 /**
- * Get track duration in milliseconds from contract v3.3.2
+ * Get track duration in milliseconds from contract v4.1.0
  * Prefers duration_ms, falls back to duration * 1000 (deprecated field)
  */
 export function getTrackDurationMs(track: Track): number {
@@ -88,7 +92,7 @@ export function getTrackDurationMs(track: Track): number {
 }
 
 /**
- * Get track duration in seconds from contract v3.3.2
+ * Get track duration in seconds from contract v4.1.0
  */
 export function getTrackDurationSeconds(track: Track): number {
   if (!track) return 0
@@ -100,11 +104,11 @@ export function getTrackDurationSeconds(track: Track): number {
 }
 
 /**
- * Ensure track has all required fields from contract v3.3.2
+ * Ensure track has all required fields from contract v4.1.0
  */
 export function normalizeTrack(track: Track): Track {
   if (!track) return track
-  // Contract v3.3.2 - Track uses 'number' field
+  // Contract v4.1.0 - Track uses 'track_number' field
   return track
 }
 
@@ -235,7 +239,7 @@ export function createTrackIndexMap(tracks: Track[]): Map<number, Track> {
 }
 
 /**
- * Batch update track numbers efficiently (v3.3.2 uses 'number' field)
+ * Batch update track numbers efficiently (v4.1.0 uses 'track_number' field)
  */
 export function batchUpdateTrackNumbers(tracks: Track[], newOrder: number[]): Track[] {
   if (tracks.length !== newOrder.length) {
@@ -244,6 +248,6 @@ export function batchUpdateTrackNumbers(tracks: Track[], newOrder: number[]): Tr
 
   return tracks.map((track, index) => ({
     ...track,
-    number: index + 1
+    track_number: index + 1
   }))
 }


### PR DESCRIPTION
## Summary

- Migrates frontend and backend code to use `track_number` field instead of `number` to comply with OpenAPI contracts v4.1.0
- Updates `trackFieldAccessor.ts` with backward compatibility fallback (`track_number ?? number`)
- Updates all stores, components, and socket types to use the new field name
- Updates all related unit tests with correct assertions and test data

## Related Issue

Closes #100

## Changes

### Frontend
- `front/src/types/index.ts`: Updated import path to contracts v4.1.0
- `front/src/utils/trackFieldAccessor.ts`: Updated `getTrackNumber()` and `batchUpdateTrackNumbers()` for v4.1.0
- `front/src/stores/unifiedPlaylistStore.ts`: Updated reorder optimistic updates to use `track_number`
- `front/src/types/socket.ts`: Updated `PlaylistStateData` interface
- `front/src/components/files/FilesList.vue`: Updated logging references
- All related test files updated with correct assertions

### Backend
- All track-related models and services updated to use `track_number`
- 2600+ backend tests pass

## Test Plan

- [x] All 612 frontend tests pass (`npm run test:unit`)
- [x] All 2600+ backend tests pass (`./deploy.sh --test-only`)
- [x] Backward compatibility maintained via fallback in `getTrackNumber()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)