### PR TITLE
feat(socket.io): implement leave:nfc handler for contracts v6.0.1

### DIFF
--- a/back/app/src/application/services/state_event_coordinator.py
+++ b/back/app/src/application/services/state_event_coordinator.py
@@ -151,7 +151,7 @@ class StateEventCoordinator:
 
         Args:
             position_ms: Current playback position in milliseconds
-            track_id: ID of the currently playing track
+            track_id: Filename of the currently playing track (renamed to track_filename in payload per v6.0.1)
             is_playing: Whether playback is active
             duration_ms: Optional track duration
 
@@ -176,8 +176,8 @@ class StateEventCoordinator:
                 f"Broadcasting position update #{self._position_log_counter}: {position_ms}ms, playing={is_playing}"
             )
 
-        # Create minimal payload
-        data = {"position_ms": position_ms, "track_id": track_id, "is_playing": is_playing}
+        # Create minimal payload - use track_filename per contracts v6.0.1 (renamed from track_id)
+        data = {"position_ms": position_ms, "track_filename": track_id, "is_playing": is_playing}
 
         if duration_ms is not None:
             data["duration_ms"] = duration_ms

--- a/back/app/src/common/response_models.py
+++ b/back/app/src/common/response_models.py
@@ -28,7 +28,11 @@ class ResponseStatus(str, Enum):
 
 
 class ErrorType(str, Enum):
-    """Standard error types for consistent error handling."""
+    """Standard error types for consistent error handling.
+
+    Per contracts v6.0.1, Socket.IO err:op events use a subset:
+    validation_error, not_found, permission_denied, conflict, timeout, internal_error
+    """
 
     VALIDATION_ERROR = "validation_error"
     NOT_FOUND = "not_found"
@@ -38,6 +42,7 @@ class ErrorType(str, Enum):
     INTERNAL_ERROR = "internal_error"
     CONFLICT = "conflict"
     BAD_REQUEST = "bad_request"
+    TIMEOUT = "timeout"  # Added per contracts v6.0.1 Socket.IO spec
 
 
 class BaseResponse(BaseModel, Generic[T]):
@@ -166,6 +171,7 @@ ERROR_STATUS_CODES = {
     ErrorType.SERVICE_UNAVAILABLE: 503,
     ErrorType.INTERNAL_ERROR: 500,
     ErrorType.CONFLICT: 409,
+    ErrorType.TIMEOUT: 408,  # Request Timeout
 }
 
 

--- a/back/app/src/common/socket_events.py
+++ b/back/app/src/common/socket_events.py
@@ -29,6 +29,7 @@ class SocketEventType(str, Enum):
     JOIN_PLAYLIST = "join:playlist"
     LEAVE_PLAYLIST = "leave:playlist"
     JOIN_NFC = "join:nfc"
+    LEAVE_NFC = "leave:nfc"
     ACK_JOIN = "ack:join"
     ACK_LEAVE = "ack:leave"
 

--- a/back/app/src/routes/handlers/subscription_handlers.py
+++ b/back/app/src/routes/handlers/subscription_handlers.py
@@ -60,6 +60,7 @@ class SubscriptionHandlers:
         - 'leave:playlists': Unsubscribe from global playlist updates
         - 'leave:playlist': Unsubscribe from specific playlist updates
         - 'join:nfc': Subscribe to NFC association session updates
+        - 'leave:nfc': Unsubscribe from NFC association session updates
         """
 
         @self.sio.on("join:playlists")
@@ -131,13 +132,14 @@ class SubscriptionHandlers:
             logger.info(f"Client {sid} joining playlist room: {room}")
             await self.state_manager.subscribe_client(sid, room)
 
-            # Send acknowledgment
+            # Send acknowledgment with server_seq as required by contracts v6.0.1
             await self.sio.emit(
                 "ack:join",
                 {
                     "room": room,
                     "playlist_id": playlist_id,
                     "success": True,
+                    "server_seq": self.state_manager.get_global_sequence(),
                     "playlist_seq": self.state_manager.get_playlist_sequence(
                         playlist_id
                     ),
@@ -245,5 +247,38 @@ class SubscriptionHandlers:
                     "success": True,
                     "server_seq": self.state_manager.get_global_sequence(),
                 },
+                room=sid,
+            )
+
+        @self.sio.on("leave:nfc")
+        @handle_http_errors()
+        async def handle_leave_nfc(sid: str, data: dict[str, Any]) -> None:
+            """Unsubscribe client from NFC association session room.
+
+            This is the symmetric counterpart to 'join:nfc' for proper NFC room
+            unsubscription as required by contracts v6.0.1.
+
+            Args:
+                sid: The Socket.IO session identifier for the unsubscribing client
+                data: The request payload containing 'assoc_id' (association ID)
+
+            Raises:
+                ValueError: If 'assoc_id' is not provided in data
+
+            Side Effects:
+                - Removes client from 'nfc:{assoc_id}' room
+                - Emits 'ack:leave' acknowledgment to client
+                - Logs unsubscription at INFO level
+            """
+            assoc_id = data.get("assoc_id")
+            if not assoc_id:
+                raise ValueError("assoc_id is required")
+
+            room = SocketRooms.nfc(assoc_id)
+            logger.info(f"Client {sid} leaving NFC room: {room}")
+            await self.state_manager.unsubscribe_client(sid, room)
+            await self.sio.emit(
+                "ack:leave",
+                {"room": room, "success": True},
                 room=sid,
             )

--- a/back/tests/contracts/test_socketio_subscription_contract.py
+++ b/back/tests/contracts/test_socketio_subscription_contract.py
@@ -2,7 +2,7 @@
 
 Validates that Socket.IO room subscription events conform to the expected contract.
 
-Progress: 7/7 events tested ✅
+Progress: 8/8 events tested ✅ (including leave:nfc per contracts v6.0.1)
 """
 
 import pytest
@@ -308,3 +308,65 @@ class TestSocketIOSubscriptionContract:
         assert isinstance(payload["success"], bool), "success must be boolean"
 
         assert payload["success"] is True, "success should be true for successful leave"
+
+    async def test_leave_nfc_event_contract(self, socketio_handlers, mock_state_manager):
+        """Test 'leave:nfc' event - Unsubscribe from NFC association session.
+
+        Contract (v6.0.1):
+        - Direction: client_to_server
+        - Payload: {assoc_id: str (required)}
+        - Server should remove client from 'nfc:{assoc_id}' room
+        - Server should emit ack:leave confirmation
+        """
+        handler = socketio_handlers._registered_handlers['leave:nfc']
+        test_sid = "test-client-leave-nfc"
+        test_assoc_id = "test-assoc-leave-123"
+
+        # Test successful leave
+        await handler(test_sid, {"assoc_id": test_assoc_id})
+
+        # Verify unsubscribe_client called with correct room
+        expected_room = f"nfc:{test_assoc_id}"
+        mock_state_manager.unsubscribe_client.assert_called_once_with(test_sid, expected_room)
+
+        # Verify ack:leave emitted
+        call_args = socketio_handlers.sio.emit.call_args
+        assert call_args[0][0] == "ack:leave", "Should emit ack:leave"
+
+        payload = call_args[0][1]
+        assert payload["room"] == expected_room, "Room should be nfc:{assoc_id}"
+        assert payload["success"] is True, "Success should be true"
+
+    async def test_leave_nfc_requires_assoc_id(self, socketio_handlers, mock_state_manager):
+        """Test 'leave:nfc' event requires assoc_id.
+
+        Contract (v6.0.1):
+        - Payload: {assoc_id: str (required)}
+        - Error if assoc_id missing
+        """
+        handler = socketio_handlers._registered_handlers['leave:nfc']
+        test_sid = "test-client-leave-nfc-error"
+
+        # Test error when assoc_id missing
+        with pytest.raises(HTTPException) as exc_info:
+            await handler(test_sid, {})
+        assert "assoc_id is required" in str(exc_info.value.detail)
+
+    async def test_join_playlist_includes_server_seq(self, socketio_handlers, mock_state_manager):
+        """Test 'join:playlist' event includes server_seq in ack:join.
+
+        Contract (v6.0.1):
+        - ack:join must include server_seq for all subscription events
+        """
+        handler = socketio_handlers._registered_handlers['join:playlist']
+        test_sid = "test-client-playlist-seq"
+        test_playlist_id = "test-playlist-seq-123"
+
+        await handler(test_sid, {"playlist_id": test_playlist_id})
+
+        # Verify ack:join includes server_seq
+        call_args = socketio_handlers.sio.emit.call_args
+        payload = call_args[0][1]
+
+        assert "server_seq" in payload, "ack:join for join:playlist must include server_seq (v6.0.1)"
+        assert isinstance(payload["server_seq"], int), "server_seq must be an integer"

--- a/front/src/tests/contracts/socketio/state.contract.test.ts
+++ b/front/src/tests/contracts/socketio/state.contract.test.ts
@@ -36,16 +36,17 @@ describe('Socket.IO State Events Contract Tests', () => {
 
   it('should validate state:track_position event payload structure', () => {
     /**
-     * Contract:
+     * Contract v6.0.1:
      * - Event: 'state:track_position'
      * - Lightweight position updates (200ms interval)
-     * - Data: {position_ms: number, track_id?: string, is_playing: boolean, duration_ms?: number}
+     * - Data: {position_ms: number, track_filename?: string, is_playing: boolean, duration_ms?: number}
+     * - Note: track_id was renamed to track_filename in v6.0.0
      */
     const trackPositionPayload = {
       event_type: 'state:track_position',
       data: {
         position_ms: 45200,
-        track_id: 'track-123',
+        track_filename: 'track-123.mp3',
         is_playing: true,
         duration_ms: 180000
       },


### PR DESCRIPTION
## Summary

### Backend Changes - Contracts v6.0.1 Compliance

- Add `LEAVE_NFC` event type to `SocketEventType` enum
- Implement `leave:nfc` handler for NFC room unsubscription
- Add `server_seq` to `ack:join` for `join:playlist` event (v6.0.1 requirement)
- Add contract tests for `leave:nfc` and `server_seq` validation
- **Fix backend/frontend sync**: Rename `track_id` to `track_filename` in `state:track_position` event payload
- **Add `timeout` to ErrorType enum** as required by Socket.IO contracts v6.0.1
- Update contracts submodule to v6.0.1

## Related Issues

- Closes #136 
- Part of EPIC #134

## Files Changed

### Backend
- `back/app/src/common/socket_events.py` - Added `LEAVE_NFC` event type
- `back/app/src/common/response_models.py` - Added `TIMEOUT` to ErrorType enum
- `back/app/src/routes/handlers/subscription_handlers.py` - Implemented `leave:nfc` handler, added `server_seq` to `ack:join`
- `back/app/src/application/services/state_event_coordinator.py` - Changed `track_id` → `track_filename` in position event
- `back/tests/contracts/test_socketio_subscription_contract.py` - Added contract tests

### Frontend (sync fix)
- `front/src/tests/contracts/socketio/state.contract.test.ts` - Updated test to expect `track_filename`

## Test plan

- [x] Unit tests pass locally (`./run_tests.sh`) - 122 passed
- [x] Contract tests validate `leave:nfc` handler
- [x] Contract tests validate `server_seq` in `ack:join`
- [x] Frontend tests pass with updated `track_filename` field - 612 passed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)