### PR TITLE
chore(frontend): update types to contracts v6.0.1

### DIFF
--- a/front/src/services/SocketService.class.ts
+++ b/front/src/services/SocketService.class.ts
@@ -76,7 +76,7 @@ export interface EventHandlers {
   'state:playlist': (data: StateEventEnvelope<Playlist>) => void
   'state:player': (data: StateEventEnvelope<PlayerState>) => void
   'state:track_progress': (data: StateEventEnvelope<TrackProgress>) => void
-  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_id: string; is_playing: boolean; duration_ms?: number }>) => void
+  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_filename?: string | null; is_playing: boolean; duration_ms?: number }>) => void
   'state:track': (data: StateEventEnvelope<any>) => void
   'state:playlist_deleted': (data: StateEventEnvelope<{ playlist_id: string; message?: string }>) => void
   'state:playlist_created': (data: StateEventEnvelope<{ playlist: Playlist }>) => void

--- a/front/src/services/socketService.ts
+++ b/front/src/services/socketService.ts
@@ -69,7 +69,7 @@ export interface EventHandlers {
   'state:playlist': (data: StateEventEnvelope<Playlist>) => void
   'state:player': (data: StateEventEnvelope<PlayerState>) => void
   'state:track_progress': (data: StateEventEnvelope<TrackProgress>) => void
-  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_id: string; is_playing: boolean; duration_ms?: number }>) => void
+  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_filename?: string | null; is_playing: boolean; duration_ms?: number }>) => void
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   'state:track': (data: StateEventEnvelope<any>) => void
   'state:playlist_deleted': (data: StateEventEnvelope<{ playlist_id: string; message?: string }>) => void

--- a/front/src/stores/serverStateStore.ts
+++ b/front/src/stores/serverStateStore.ts
@@ -461,7 +461,8 @@ export const useServerStateStore = defineStore('serverState', () => {
 
   function handleTrackPosition(event: StateEvent) {
     // Lightweight position-only updates with strategic logging
-    const data = event.data as { position_ms?: number; duration_ms?: number; is_playing?: boolean; track_id?: string }
+    // Note: track_filename renamed from track_id in contracts v6.0.0
+    const data = event.data as { position_ms?: number; duration_ms?: number; is_playing?: boolean; track_filename?: string | null }
 
     // Log first event for debugging and every subsequent event for a few seconds
     if (!firstPositionLogged) {
@@ -493,8 +494,9 @@ export const useServerStateStore = defineStore('serverState', () => {
       }
 
       // Update active track ID if provided (for consistency)
-      if (data?.track_id && data.track_id !== playerState.value.active_track_id) {
-        playerState.value.active_track_id = data.track_id
+      // Note: track_filename renamed from track_id in contracts v6.0.0, stored in active_track_id for backward compat
+      if (data?.track_filename && data.track_filename !== playerState.value.active_track_id) {
+        playerState.value.active_track_id = data.track_filename
       }
     }
 

--- a/front/src/tests/contracts/schemas/socketio_contracts.json
+++ b/front/src/tests/contracts/schemas/socketio_contracts.json
@@ -2,7 +2,26 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TheOpenMusicBox Socket.IO Contracts",
   "description": "Complete contract definitions for all Socket.IO events based on DDD implementation analysis",
-  "version": "4.0.0",
+  "version": "6.0.1",
+  "deprecations": {
+    "description": "Fields and events marked for removal in future versions",
+    "fields": {
+      "duration": {
+        "deprecated_in": "6.0.0",
+        "removed_in": "7.0.0",
+        "replacement": "duration_ms",
+        "reason": "Use milliseconds for precision. duration (seconds) will be removed."
+      }
+    },
+    "events": {
+      "nfc_status": {
+        "deprecated_in": "6.0.0",
+        "removed_in": "7.0.0",
+        "replacement": "nfc_association_state",
+        "reason": "nfc_association_state has more complete state enum and additional fields"
+      }
+    }
+  },
   "event_envelope_format": {
     "description": "All state events use standardized envelope format via StateEventCoordinator",
     "schema": {
@@ -14,7 +33,10 @@
         "timestamp": {"type": "number"},
         "event_id": {"type": "string"},
         "playlist_id": {"type": ["string", "null"]},
-        "track_id": {"type": ["string", "null"]}
+        "track_filename": {
+          "type": ["string", "null"],
+          "description": "Filename of the associated track (same as Track.filename)"
+        }
       },
       "required": ["event_type", "server_seq", "data", "timestamp", "event_id"]
     }
@@ -124,6 +146,17 @@
           },
           "description": "Unsubscribe from specific playlist updates"
         },
+        "leave:nfc": {
+          "direction": "client_to_server",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "assoc_id": {"type": "string"}
+            },
+            "required": ["assoc_id"]
+          },
+          "description": "Unsubscribe from NFC association session"
+        },
         "ack:join": {
           "direction": "server_to_client",
           "payload": {
@@ -131,12 +164,12 @@
             "properties": {
               "room": {"type": "string"},
               "success": {"type": "boolean"},
-              "server_seq": {"type": "number"},
+              "server_seq": {"type": "number", "description": "Current server sequence for state synchronization"},
               "playlist_seq": {"type": "number"},
               "playlist_id": {"type": "string"},
               "message": {"type": "string"}
             },
-            "required": ["room", "success"]
+            "required": ["room", "success", "server_seq"]
           },
           "description": "Room join acknowledgment"
         },
@@ -190,7 +223,10 @@
             "type": "object",
             "properties": {
               "position_ms": {"type": "integer"},
-              "track_id": {"type": ["string", "null"]},
+              "track_filename": {
+                "type": ["string", "null"],
+                "description": "Filename of the current track (same as Track.filename)"
+              },
               "is_playing": {"type": "boolean"},
               "duration_ms": {"type": ["integer", "null"]}
             },
@@ -336,7 +372,7 @@
           "description": "Playlist update notification",
           "frequency": "on_demand"
         },
-        "state:track_deleted": {
+        "state:tracks_deleted": {
           "direction": "server_to_client",
           "envelope": true,
           "data_schema": {
@@ -345,12 +381,15 @@
               "playlist_id": {"type": "string"},
               "track_numbers": {
                 "type": "array",
-                "items": {"type": "integer"}
-              }
+                "items": {"type": "integer"},
+                "description": "List of 1-based track numbers that were deleted"
+              },
+              "operation": {"type": "string"},
+              "server_seq": {"type": "number", "description": "Server sequence for state synchronization"}
             },
-            "required": ["playlist_id", "track_numbers"]
+            "required": ["playlist_id", "track_numbers", "server_seq"]
           },
-          "description": "Track deletion notification",
+          "description": "Track deletion notification. track_numbers contains 1-based positions.",
           "frequency": "on_demand"
         },
         "state:track_added": {
@@ -417,7 +456,11 @@
               "client_op_id": {"type": "string"},
               "success": {"type": "boolean", "const": false},
               "message": {"type": "string"},
-              "error_type": {"type": "string"},
+              "error_type": {
+                "type": "string",
+                "enum": ["validation_error", "not_found", "permission_denied", "conflict", "timeout", "internal_error"],
+                "description": "Categorized error type for client handling"
+              },
               "server_seq": {"type": "number"}
             },
             "required": ["client_op_id", "success", "message", "server_seq"]
@@ -499,6 +542,10 @@
       "events": {
         "nfc_status": {
           "direction": "server_to_client",
+          "deprecated": true,
+          "deprecation_note": "Use nfc_association_state instead. Will be removed in v7.0.0",
+          "x-platform": "rpi",
+          "x-note": "RPI broadcasts to room nfc:{assoc_id}. ESP32 uses nfc_association_state instead.",
           "payload": {
             "type": "object",
             "properties": {
@@ -510,10 +557,12 @@
             },
             "required": ["assoc_id", "state"]
           },
-          "description": "NFC session status updates"
+          "description": "DEPRECATED: NFC session status updates. Use nfc_association_state instead."
         },
         "nfc_association_state": {
           "direction": "server_to_client",
+          "x-platform": ["esp32", "rpi"],
+          "x-note": "ESP32 broadcasts globally to all clients. RPI also supports this for compatibility.",
           "payload": {
             "type": "object",
             "properties": {

--- a/front/src/tests/contracts/socketio/state.contract.test.ts
+++ b/front/src/tests/contracts/socketio/state.contract.test.ts
@@ -36,16 +36,17 @@ describe('Socket.IO State Events Contract Tests', () => {
 
   it('should validate state:track_position event payload structure', () => {
     /**
-     * Contract:
+     * Contract (v6.0.1):
      * - Event: 'state:track_position'
-     * - Lightweight position updates (200ms interval)
-     * - Data: {position_ms: number, track_id?: string, is_playing: boolean, duration_ms?: number}
+     * - Lightweight position updates (500ms interval)
+     * - Data: {position_ms: number, track_filename?: string, is_playing: boolean, duration_ms?: number}
+     * - Note: track_filename renamed from track_id in v6.0.0
      */
     const trackPositionPayload = {
       event_type: 'state:track_position',
       data: {
         position_ms: 45200,
-        track_id: 'track-123',
+        track_filename: 'song.mp3',  // Renamed from track_id in v6.0.0
         is_playing: true,
         duration_ms: 180000
       },

--- a/front/src/types/contracts.ts
+++ b/front/src/types/contracts.ts
@@ -18,7 +18,8 @@ export interface ApiResponse<T = any> {
 export interface ApiError {
   status: 'error';
   message: string;
-  error_type: 'validation_error' | 'not_found' | 'permission_denied' | 'rate_limit_exceeded' | 'service_unavailable' | 'internal_error' | 'conflict' | 'bad_request';
+  /** Error types per contracts v6.0.1 - includes timeout for Socket.IO */
+  error_type: 'validation_error' | 'not_found' | 'permission_denied' | 'rate_limit_exceeded' | 'service_unavailable' | 'internal_error' | 'conflict' | 'bad_request' | 'timeout';
   details?: Record<string, any>;
   timestamp: number;
   request_id: string;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,12 +1,12 @@
 /**
  * Frontend Types - Central Export Point
  *
- * Uses ONLY generated types from OpenAPI Contract v4.1.0
+ * Uses ONLY generated types from OpenAPI Contract v6.0.1
  * Zero legacy code - 100% contract-driven development
  */
 
-// Import generated types from contracts v4.1.0
-import type { components } from '../../../contracts/releases/4.1.0-7dc3483/typescript/api-types';
+// Import generated types from contracts v6.0.1
+import type { components } from '../../../contracts/releases/6.0.1/typescript/api-types';
 
 // Export core data types from OpenAPI schema
 export type Track = components['schemas']['Track'];
@@ -47,7 +47,7 @@ export type PaginatedData<T> = {
   total_pages: number;
 };
 
-// Socket.IO event types
+// Socket.IO event types (v6.0.1)
 export type StateEventEnvelope<T = any> = {
   event_type: string;
   server_seq: number;
@@ -55,7 +55,8 @@ export type StateEventEnvelope<T = any> = {
   timestamp: number;
   event_id: string;
   playlist_id?: string | null;
-  track_id?: string | null;
+  /** Renamed from track_id in v6.0.0 - contains track filename */
+  track_filename?: string | null;
 };
 
 export type OperationAck = {
@@ -79,7 +80,8 @@ export type UploadStatus = 'pending' | 'uploading' | 'complete' | 'error';
 
 export type TrackProgress = {
   position_ms: number;
-  track_id?: string | null;
+  /** Renamed from track_id in v6.0.0 - contains track filename */
+  track_filename?: string | null;
   is_playing: boolean;
   duration_ms?: number | null;
 };

--- a/front/src/types/socket.ts
+++ b/front/src/types/socket.ts
@@ -59,10 +59,13 @@ export interface PlaylistStateData {
   id: string;
   title: string;
   tracks?: Array<{
-    track_number: number;  // OpenAPI v4.1.0
+    track_number: number;  // 1-based position per OpenAPI v6.0.1
     title: string;
     filename: string;
+    /** @deprecated Use duration_ms instead */
     duration?: number;
+    /** Duration in milliseconds (preferred over duration) */
+    duration_ms?: number;
   }>;
   nfc_tag_id?: string;
   server_seq?: number;
@@ -71,8 +74,13 @@ export interface PlaylistStateData {
 export interface PlayerStateData {
   is_playing: boolean;
   active_playlist_id?: string;
+  /** @deprecated Will be renamed to active_track_filename in v7.0.0 */
   active_track_id?: string;
+  /** Track number (1-based) in current playlist */
+  active_track_number?: number;
   position_ms: number;
+  /** Duration in milliseconds */
+  duration_ms?: number;
   can_prev: boolean;
   can_next: boolean;
   server_seq: number;
@@ -81,6 +89,8 @@ export interface PlayerStateData {
 export interface TrackProgressData {
   position_ms: number;
   duration_ms: number;
+  /** Track filename (renamed from track_id in v6.0.0) */
+  track_filename?: string;
   track_number?: number;
   playlist_id?: string;
 }


### PR DESCRIPTION
## Summary

### Frontend Changes - Contracts v6.0.1 Compliance

- Update TypeScript types import from `contracts/releases/4.1.0-7dc3483` to `contracts/releases/6.0.1`
- Rename `track_id` to `track_filename` in `StateEventEnvelope` and `TrackProgress` types
- Update `state:track_position` event type in socket services
- Update `serverStateStore` to handle `track_filename` field
- Update contract test schemas to v6.0.1
- Update test fixtures to use `track_filename`

### Socket Types Alignment (socket.ts)
- Add `duration_ms` to `PlaylistStateData` tracks (preferred over `duration`)
- Add `active_track_number` and `duration_ms` to `PlayerStateData`
- Add `track_filename` to `TrackProgressData`
- Mark deprecated fields with JSDoc `@deprecated` annotations
- Update version reference comments to v6.0.1

### Error Types (contracts.ts)
- Add `timeout` to `ApiError.error_type` union to align with Socket.IO contracts

## Breaking Changes

The `track_id` field has been renamed to `track_filename` in:
- `StateEventEnvelope` type
- `TrackProgress` type
- `state:track_position` event data

This aligns with contracts v6.0.0 which standardizes track identification using filenames.

## Related Issues

- Closes #137
- Part of EPIC #134

## Test plan

- [x] Contract tests updated and pass
- [x] TypeScript types align with v6.0.1 schema
- [x] All frontend tests pass - 612 passed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)