### PR TITLE
feat(contracts): align rpi-firmware with contracts v6.0.1

### DIFF
--- a/back/app/src/application/controllers/playback_coordinator_controller.py
+++ b/back/app/src/application/controllers/playback_coordinator_controller.py
@@ -332,6 +332,8 @@ class PlaybackCoordinator:
             "active_playlist_title": playlist_info["playlist_name"],
             "active_track": current_track,
             "active_track_id": current_track.get("id") if current_track else None,
+            # track_filename per contracts v6.0.1 - use filename, not id
+            "active_track_filename": current_track.get("filename") if current_track else None,
             "track_index": playlist_info["current_track_number"],
             "track_count": playlist_info["total_tracks"],
             "can_next": playlist_info["can_next"],

--- a/back/app/src/application/services/state_event_coordinator.py
+++ b/back/app/src/application/services/state_event_coordinator.py
@@ -144,14 +144,14 @@ class StateEventCoordinator:
         return envelope
 
     async def broadcast_position_update(
-        self, position_ms: int, track_id: str, is_playing: bool, duration_ms: int | None = None
+        self, position_ms: int, track_filename: str, is_playing: bool, duration_ms: int | None = None
     ) -> dict | None:
         """
         Broadcast a lightweight position update with throttling.
 
         Args:
             position_ms: Current playback position in milliseconds
-            track_id: Filename of the currently playing track (renamed to track_filename in payload per v6.0.1)
+            track_filename: Filename of the currently playing track (per contracts v6.0.1)
             is_playing: Whether playback is active
             duration_ms: Optional track duration
 
@@ -176,8 +176,8 @@ class StateEventCoordinator:
                 f"Broadcasting position update #{self._position_log_counter}: {position_ms}ms, playing={is_playing}"
             )
 
-        # Create minimal payload - use track_filename per contracts v6.0.1 (renamed from track_id)
-        data = {"position_ms": position_ms, "track_filename": track_id, "is_playing": is_playing}
+        # Create minimal payload per contracts v6.0.1
+        data = {"position_ms": position_ms, "track_filename": track_filename, "is_playing": is_playing}
 
         if duration_ms is not None:
             data["duration_ms"] = duration_ms

--- a/back/app/src/application/services/state_event_coordinator.py
+++ b/back/app/src/application/services/state_event_coordinator.py
@@ -151,7 +151,7 @@ class StateEventCoordinator:
 
         Args:
             position_ms: Current playback position in milliseconds
-            track_id: ID of the currently playing track
+            track_id: Filename of the currently playing track (renamed to track_filename in payload per v6.0.1)
             is_playing: Whether playback is active
             duration_ms: Optional track duration
 
@@ -176,8 +176,8 @@ class StateEventCoordinator:
                 f"Broadcasting position update #{self._position_log_counter}: {position_ms}ms, playing={is_playing}"
             )
 
-        # Create minimal payload
-        data = {"position_ms": position_ms, "track_id": track_id, "is_playing": is_playing}
+        # Create minimal payload - use track_filename per contracts v6.0.1 (renamed from track_id)
+        data = {"position_ms": position_ms, "track_filename": track_id, "is_playing": is_playing}
 
         if duration_ms is not None:
             data["duration_ms"] = duration_ms

--- a/back/app/src/common/response_models.py
+++ b/back/app/src/common/response_models.py
@@ -28,7 +28,11 @@ class ResponseStatus(str, Enum):
 
 
 class ErrorType(str, Enum):
-    """Standard error types for consistent error handling."""
+    """Standard error types for consistent error handling.
+
+    Per contracts v6.0.1, Socket.IO err:op events use a subset:
+    validation_error, not_found, permission_denied, conflict, timeout, internal_error
+    """
 
     VALIDATION_ERROR = "validation_error"
     NOT_FOUND = "not_found"
@@ -38,6 +42,7 @@ class ErrorType(str, Enum):
     INTERNAL_ERROR = "internal_error"
     CONFLICT = "conflict"
     BAD_REQUEST = "bad_request"
+    TIMEOUT = "timeout"  # Added per contracts v6.0.1 Socket.IO spec
 
 
 class BaseResponse(BaseModel, Generic[T]):
@@ -166,6 +171,7 @@ ERROR_STATUS_CODES = {
     ErrorType.SERVICE_UNAVAILABLE: 503,
     ErrorType.INTERNAL_ERROR: 500,
     ErrorType.CONFLICT: 409,
+    ErrorType.TIMEOUT: 408,  # Request Timeout
 }
 
 

--- a/back/app/src/common/socket_events.py
+++ b/back/app/src/common/socket_events.py
@@ -29,6 +29,7 @@ class SocketEventType(str, Enum):
     JOIN_PLAYLIST = "join:playlist"
     LEAVE_PLAYLIST = "leave:playlist"
     JOIN_NFC = "join:nfc"
+    LEAVE_NFC = "leave:nfc"
     ACK_JOIN = "ack:join"
     ACK_LEAVE = "ack:leave"
 

--- a/back/app/src/routes/handlers/subscription_handlers.py
+++ b/back/app/src/routes/handlers/subscription_handlers.py
@@ -60,6 +60,7 @@ class SubscriptionHandlers:
         - 'leave:playlists': Unsubscribe from global playlist updates
         - 'leave:playlist': Unsubscribe from specific playlist updates
         - 'join:nfc': Subscribe to NFC association session updates
+        - 'leave:nfc': Unsubscribe from NFC association session updates
         """
 
         @self.sio.on("join:playlists")
@@ -131,13 +132,14 @@ class SubscriptionHandlers:
             logger.info(f"Client {sid} joining playlist room: {room}")
             await self.state_manager.subscribe_client(sid, room)
 
-            # Send acknowledgment
+            # Send acknowledgment with server_seq as required by contracts v6.0.1
             await self.sio.emit(
                 "ack:join",
                 {
                     "room": room,
                     "playlist_id": playlist_id,
                     "success": True,
+                    "server_seq": self.state_manager.get_global_sequence(),
                     "playlist_seq": self.state_manager.get_playlist_sequence(
                         playlist_id
                     ),
@@ -245,5 +247,38 @@ class SubscriptionHandlers:
                     "success": True,
                     "server_seq": self.state_manager.get_global_sequence(),
                 },
+                room=sid,
+            )
+
+        @self.sio.on("leave:nfc")
+        @handle_http_errors()
+        async def handle_leave_nfc(sid: str, data: dict[str, Any]) -> None:
+            """Unsubscribe client from NFC association session room.
+
+            This is the symmetric counterpart to 'join:nfc' for proper NFC room
+            unsubscription as required by contracts v6.0.1.
+
+            Args:
+                sid: The Socket.IO session identifier for the unsubscribing client
+                data: The request payload containing 'assoc_id' (association ID)
+
+            Raises:
+                ValueError: If 'assoc_id' is not provided in data
+
+            Side Effects:
+                - Removes client from 'nfc:{assoc_id}' room
+                - Emits 'ack:leave' acknowledgment to client
+                - Logs unsubscription at INFO level
+            """
+            assoc_id = data.get("assoc_id")
+            if not assoc_id:
+                raise ValueError("assoc_id is required")
+
+            room = SocketRooms.nfc(assoc_id)
+            logger.info(f"Client {sid} leaving NFC room: {room}")
+            await self.state_manager.unsubscribe_client(sid, room)
+            await self.sio.emit(
+                "ack:leave",
+                {"room": room, "success": True},
                 room=sid,
             )

--- a/back/app/src/services/track_progress_service.py
+++ b/back/app/src/services/track_progress_service.py
@@ -232,7 +232,9 @@ class TrackProgressService:
 
         # Use correct field names from PlaybackCoordinator status
         is_playing = status.get("is_playing", False)
-        track_id = status.get("active_track_id")
+        # Per contracts v6.0.1: use active_track_filename (actual filename) for track_filename field
+        # Fallback to active_track_id for backward compatibility with older coordinators
+        track_filename = status.get("active_track_filename") or status.get("active_track_id")
 
         return {
             "current_time_ms": current_time_ms,
@@ -240,7 +242,7 @@ class TrackProgressService:
             "current_time": current_time,
             "duration": duration,
             "is_playing": is_playing,
-            "track_id": track_id,
+            "track_filename": track_filename,
         }
 
     async def _handle_track_events(self, status: dict, position_data: dict) -> None:
@@ -263,7 +265,7 @@ class TrackProgressService:
             logger.debug(
                 f"📍 Progress emission #{self._emit_counter}: "
                 f"pos={position_data['current_time']:.1f}s/{position_data['duration']:.1f}s, "
-                f"playing={position_data['is_playing']}, track_id={position_data['track_id']}"
+                f"playing={position_data['is_playing']}, track_filename={position_data['track_filename']}"
             )
 
         # Check for stuck position
@@ -288,14 +290,14 @@ class TrackProgressService:
         if not self._validate_position_data(
             position_data["current_time"],
             position_data["duration"],
-            position_data["track_id"]
+            position_data["track_filename"]
         ):
             if not hasattr(self, "_validation_fail_logged"):
                 logger.warning(
                     f"❌ VALIDATION FAILED (attempt #{self._emission_attempt_count}): "
                     f"time={position_data['current_time']}, "
                     f"duration={position_data['duration']}, "
-                    f"track_id={position_data['track_id']}"
+                    f"track_filename={position_data['track_filename']}"
                 )
                 self._validation_fail_logged = True
             return False
@@ -305,7 +307,7 @@ class TrackProgressService:
             logger.info(
                 f"✅ FIRST VALID position: time={position_data['current_time']:.1f}s, "
                 f"duration={position_data['duration']:.1f}s, "
-                f"track_id={position_data['track_id']}, playing={position_data['is_playing']}"
+                f"track_filename={position_data['track_filename']}, playing={position_data['is_playing']}"
             )
             self._first_valid_logged = True
 
@@ -317,13 +319,13 @@ class TrackProgressService:
         if not hasattr(self, "_first_broadcast_logged"):
             logger.info(
                 f"📡 FIRST BROADCAST attempt: pos={position_data['current_time_ms']}ms, "
-                f"track={position_data['track_id']}, playing={position_data['is_playing']}"
+                f"track_filename={position_data['track_filename']}, playing={position_data['is_playing']}"
             )
             self._first_broadcast_logged = True
 
         result = await self.state_manager.broadcast_position_update(
             position_ms=position_data["current_time_ms"],
-            track_id=str(position_data["track_id"]) if position_data["track_id"] else "unknown",
+            track_filename=str(position_data["track_filename"]) if position_data["track_filename"] else "unknown",
             is_playing=position_data["is_playing"],
             duration_ms=position_data["duration_ms"] if position_data["duration_ms"] > 0 else None,
         )
@@ -346,14 +348,16 @@ class TrackProgressService:
             logger.info(f"✅ FIRST BROADCAST SUCCESS: {result.get('event_type', 'unknown')}")
             self._broadcast_success_logged = True
 
-    def _validate_position_data(self, current_time: float, duration: float, track_id) -> bool:
+    def _validate_position_data(self, current_time: float, duration: float, track_filename) -> bool:
         """Validate position data before emission."""
         # DIAGNOSTIC: Track validation failures
         if not hasattr(self, "_validation_check_count"):
             self._validation_check_count = 0
         self._validation_check_count += 1
 
-        # Allow track_id to be None or empty string temporarily
+        # Allow track_filename to be None or empty string temporarily
+        # (track_filename is the filename, not a required field per contract)
+        _ = track_filename  # Mark as used for validation context
         if current_time is None:
             return False
 

--- a/back/tests/contracts/socketio_contracts.json
+++ b/back/tests/contracts/socketio_contracts.json
@@ -190,13 +190,13 @@
             "type": "object",
             "properties": {
               "position_ms": {"type": "integer"},
-              "track_id": {"type": ["string", "null"]},
+              "track_filename": {"type": ["string", "null"], "description": "Filename of current track (per v6.0.1)"},
               "is_playing": {"type": "boolean"},
               "duration_ms": {"type": ["integer", "null"]}
             },
             "required": ["position_ms", "is_playing"]
           },
-          "description": "Lightweight position updates for smooth UI",
+          "description": "Lightweight position updates for smooth UI (v6.0.1: track_filename replaces track_id)",
           "frequency": "500ms_intervals"
         },
         "state:playlists": {

--- a/back/tests/contracts/test_socketio_state_contract.py
+++ b/back/tests/contracts/test_socketio_state_contract.py
@@ -67,15 +67,17 @@ class TestSocketIOStateContract:
     async def test_state_track_position_event_contract(self):
         """Test 'state:track_position' event - Track playback position updates.
 
-        Contract:
+        Contract (v6.0.1):
         - Direction: server_to_client
-        - Event envelope format with data: {position: number, duration: number}
-        - Broadcast frequently during playback
+        - Event envelope format with data: {position_ms: integer, is_playing: boolean, track_filename?: string, duration_ms?: integer}
+        - Required fields: position_ms, is_playing
+        - Broadcast frequently during playback (500ms intervals)
         """
         position_data = {
-            "position": 45.2,
-            "duration": 180.5,
-            "track_id": "track-789"
+            "position_ms": 45200,  # Position in milliseconds
+            "is_playing": True,
+            "track_filename": "song.mp3",  # Per v6.0.1 - actual filename, not ID
+            "duration_ms": 180500  # Duration in milliseconds
         }
 
         event = SocketEventBuilder.create_state_event(
@@ -85,10 +87,14 @@ class TestSocketIOStateContract:
         )
 
         self.verify_event_envelope(event, SocketEventType.STATE_TRACK_POSITION)
-        assert "position" in event["data"]
-        assert "duration" in event["data"]
-        assert isinstance(event["data"]["position"], (int, float))
-        assert isinstance(event["data"]["duration"], (int, float))
+        # Per contracts v6.0.1 - required fields
+        assert "position_ms" in event["data"]
+        assert "is_playing" in event["data"]
+        assert isinstance(event["data"]["position_ms"], int)
+        assert isinstance(event["data"]["is_playing"], bool)
+        # Optional fields
+        assert "track_filename" in event["data"]
+        assert "duration_ms" in event["data"]
 
     async def test_state_playlists_event_contract(self):
         """Test 'state:playlists' event - Global playlists list broadcast.

--- a/back/tests/contracts/test_socketio_subscription_contract.py
+++ b/back/tests/contracts/test_socketio_subscription_contract.py
@@ -2,7 +2,7 @@
 
 Validates that Socket.IO room subscription events conform to the expected contract.
 
-Progress: 7/7 events tested ✅
+Progress: 8/8 events tested ✅ (including leave:nfc per contracts v6.0.1)
 """
 
 import pytest
@@ -308,3 +308,65 @@ class TestSocketIOSubscriptionContract:
         assert isinstance(payload["success"], bool), "success must be boolean"
 
         assert payload["success"] is True, "success should be true for successful leave"
+
+    async def test_leave_nfc_event_contract(self, socketio_handlers, mock_state_manager):
+        """Test 'leave:nfc' event - Unsubscribe from NFC association session.
+
+        Contract (v6.0.1):
+        - Direction: client_to_server
+        - Payload: {assoc_id: str (required)}
+        - Server should remove client from 'nfc:{assoc_id}' room
+        - Server should emit ack:leave confirmation
+        """
+        handler = socketio_handlers._registered_handlers['leave:nfc']
+        test_sid = "test-client-leave-nfc"
+        test_assoc_id = "test-assoc-leave-123"
+
+        # Test successful leave
+        await handler(test_sid, {"assoc_id": test_assoc_id})
+
+        # Verify unsubscribe_client called with correct room
+        expected_room = f"nfc:{test_assoc_id}"
+        mock_state_manager.unsubscribe_client.assert_called_once_with(test_sid, expected_room)
+
+        # Verify ack:leave emitted
+        call_args = socketio_handlers.sio.emit.call_args
+        assert call_args[0][0] == "ack:leave", "Should emit ack:leave"
+
+        payload = call_args[0][1]
+        assert payload["room"] == expected_room, "Room should be nfc:{assoc_id}"
+        assert payload["success"] is True, "Success should be true"
+
+    async def test_leave_nfc_requires_assoc_id(self, socketio_handlers, mock_state_manager):
+        """Test 'leave:nfc' event requires assoc_id.
+
+        Contract (v6.0.1):
+        - Payload: {assoc_id: str (required)}
+        - Error if assoc_id missing
+        """
+        handler = socketio_handlers._registered_handlers['leave:nfc']
+        test_sid = "test-client-leave-nfc-error"
+
+        # Test error when assoc_id missing
+        with pytest.raises(HTTPException) as exc_info:
+            await handler(test_sid, {})
+        assert "assoc_id is required" in str(exc_info.value.detail)
+
+    async def test_join_playlist_includes_server_seq(self, socketio_handlers, mock_state_manager):
+        """Test 'join:playlist' event includes server_seq in ack:join.
+
+        Contract (v6.0.1):
+        - ack:join must include server_seq for all subscription events
+        """
+        handler = socketio_handlers._registered_handlers['join:playlist']
+        test_sid = "test-client-playlist-seq"
+        test_playlist_id = "test-playlist-seq-123"
+
+        await handler(test_sid, {"playlist_id": test_playlist_id})
+
+        # Verify ack:join includes server_seq
+        call_args = socketio_handlers.sio.emit.call_args
+        payload = call_args[0][1]
+
+        assert "server_seq" in payload, "ack:join for join:playlist must include server_seq (v6.0.1)"
+        assert isinstance(payload["server_seq"], int), "server_seq must be an integer"

--- a/back/tests/unit/services/test_track_progress_service.py
+++ b/back/tests/unit/services/test_track_progress_service.py
@@ -385,7 +385,8 @@ class TestTrackProgressServiceEmission:
             "position_ms": 10000,
             "duration_ms": 100000,
             "is_playing": True,
-            "active_track_id": "track-123"
+            "active_track_id": "track-123",
+            "active_track_filename": "song.mp3"  # Per contracts v6.0.1
         })
 
         service = TrackProgressService(state_manager, audio_controller)
@@ -393,7 +394,7 @@ class TestTrackProgressServiceEmission:
 
         await service.emit_immediate_position()
 
-        # Should have called broadcast_position_update
+        # Should have called broadcast_position_update with track_filename
         state_manager.broadcast_position_update.assert_called_once()
 
     @pytest.mark.asyncio
@@ -416,7 +417,8 @@ class TestTrackProgressServiceEmission:
             "position_ms": 10000,
             "duration_ms": 100000,
             "is_playing": True,
-            "active_track_id": "track-123"
+            "active_track_id": "track-123",
+            "active_track_filename": "song.mp3"
         })
 
         service = TrackProgressService(None, audio_controller)
@@ -435,7 +437,8 @@ class TestTrackProgressServiceEmission:
             "position_ms": 15000,
             "duration_ms": 120000,
             "is_playing": True,
-            "active_track_id": "track-456"
+            "active_track_id": "track-456",
+            "active_track_filename": "another_song.mp3"
         })
 
         service = TrackProgressService(state_manager, audio_controller)

--- a/front/src/components/files/FileListContainer.vue
+++ b/front/src/components/files/FileListContainer.vue
@@ -102,15 +102,30 @@ const deleteTrack = async (playlistId: string, trackNumber: number) => {
 
 // Current playing info from server state
 const playingPlaylistId = computed(() => serverStateStore.playerState.active_playlist_id)
+// Per contracts v6.0.1: use active_track_filename for track identification
+const playingTrackFilename = computed(() => serverStateStore.playerState.active_track_filename)
+// Fallback to active_track_id for backward compat with state:player events
 const playingTrackId = computed(() => serverStateStore.playerState.active_track_id)
 
 // Find the track number for the currently playing track using unified accessor
 const playingTrackNumber = computed(() => {
-  if (!playingPlaylistId.value || !playingTrackId.value) return null
-  
+  if (!playingPlaylistId.value) return null
+
   const playlistTracks = unifiedStore.getTracksForPlaylist(playingPlaylistId.value)
-  const track = playlistTracks.find(t => t.id === playingTrackId.value)
-  return track ? getTrackNumber(track) : null
+
+  // Per contracts v6.0.1: prefer matching by filename (from track_position events)
+  if (playingTrackFilename.value) {
+    const track = playlistTracks.find(t => t.filename === playingTrackFilename.value)
+    if (track) return getTrackNumber(track)
+  }
+
+  // Fallback to ID matching (from state:player events)
+  if (playingTrackId.value) {
+    const track = playlistTracks.find(t => t.id === playingTrackId.value)
+    if (track) return getTrackNumber(track)
+  }
+
+  return null
 })
 
 /**

--- a/front/src/services/SocketService.class.ts
+++ b/front/src/services/SocketService.class.ts
@@ -76,7 +76,7 @@ export interface EventHandlers {
   'state:playlist': (data: StateEventEnvelope<Playlist>) => void
   'state:player': (data: StateEventEnvelope<PlayerState>) => void
   'state:track_progress': (data: StateEventEnvelope<TrackProgress>) => void
-  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_id: string; is_playing: boolean; duration_ms?: number }>) => void
+  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_filename?: string | null; is_playing: boolean; duration_ms?: number }>) => void
   'state:track': (data: StateEventEnvelope<any>) => void
   'state:playlist_deleted': (data: StateEventEnvelope<{ playlist_id: string; message?: string }>) => void
   'state:playlist_created': (data: StateEventEnvelope<{ playlist: Playlist }>) => void

--- a/front/src/services/socketService.ts
+++ b/front/src/services/socketService.ts
@@ -69,7 +69,7 @@ export interface EventHandlers {
   'state:playlist': (data: StateEventEnvelope<Playlist>) => void
   'state:player': (data: StateEventEnvelope<PlayerState>) => void
   'state:track_progress': (data: StateEventEnvelope<TrackProgress>) => void
-  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_id: string; is_playing: boolean; duration_ms?: number }>) => void
+  'state:track_position': (data: StateEventEnvelope<{ position_ms: number; track_filename?: string | null; is_playing: boolean; duration_ms?: number }>) => void
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   'state:track': (data: StateEventEnvelope<any>) => void
   'state:playlist_deleted': (data: StateEventEnvelope<{ playlist_id: string; message?: string }>) => void

--- a/front/src/stores/serverStateStore.ts
+++ b/front/src/stores/serverStateStore.ts
@@ -461,7 +461,8 @@ export const useServerStateStore = defineStore('serverState', () => {
 
   function handleTrackPosition(event: StateEvent) {
     // Lightweight position-only updates with strategic logging
-    const data = event.data as { position_ms?: number; duration_ms?: number; is_playing?: boolean; track_id?: string }
+    // Note: track_filename renamed from track_id in contracts v6.0.0
+    const data = event.data as { position_ms?: number; duration_ms?: number; is_playing?: boolean; track_filename?: string | null }
 
     // Log first event for debugging and every subsequent event for a few seconds
     if (!firstPositionLogged) {
@@ -493,8 +494,9 @@ export const useServerStateStore = defineStore('serverState', () => {
       }
 
       // Update active track ID if provided (for consistency)
-      if (data?.track_id && data.track_id !== playerState.value.active_track_id) {
-        playerState.value.active_track_id = data.track_id
+      // Note: track_filename renamed from track_id in contracts v6.0.0, stored in active_track_id for backward compat
+      if (data?.track_filename && data.track_filename !== playerState.value.active_track_id) {
+        playerState.value.active_track_id = data.track_filename
       }
     }
 

--- a/front/src/stores/serverStateStore.ts
+++ b/front/src/stores/serverStateStore.ts
@@ -30,7 +30,8 @@ interface PlayerState {
   is_playing: boolean
   active_playlist_id: string | null
   active_playlist_title: string | null
-  active_track_id: string | null
+  active_track_id: string | null  // Track ID (from state:player)
+  active_track_filename: string | null  // Track filename (from state:track_position per v6.0.1)
   active_track: {
     id?: string
     title: string
@@ -83,6 +84,7 @@ export const useServerStateStore = defineStore('serverState', () => {
     active_playlist_id: null,
     active_playlist_title: null,
     active_track_id: null,
+    active_track_filename: null,  // Per contracts v6.0.1
     active_track: null,
     position_ms: 0,
     duration_ms: 0,
@@ -365,6 +367,8 @@ export const useServerStateStore = defineStore('serverState', () => {
         active_playlist_id: newPlaylistId ?? null,
         active_playlist_title: stateData.active_playlist_title ?? null,
         active_track_id: stateData.active_track_id ?? null,
+        // Initialize active_track_filename from active_track.filename for consistency
+        active_track_filename: stateData.active_track?.filename ?? null,
         active_track: stateData.active_track ?? null,
         position_ms: stateData.position_ms || 0,
         duration_ms: stateData.duration_ms || 0,
@@ -493,10 +497,10 @@ export const useServerStateStore = defineStore('serverState', () => {
         playerState.value.duration_ms = data.duration_ms
       }
 
-      // Update active track ID if provided (for consistency)
-      // Note: track_filename renamed from track_id in contracts v6.0.0, stored in active_track_id for backward compat
-      if (data?.track_filename && data.track_filename !== playerState.value.active_track_id) {
-        playerState.value.active_track_id = data.track_filename
+      // Update active track filename if provided (per contracts v6.0.1)
+      // track_filename contains the actual filename (e.g., "song.mp3"), not the track ID
+      if (data?.track_filename && data.track_filename !== playerState.value.active_track_filename) {
+        playerState.value.active_track_filename = data.track_filename
       }
     }
 
@@ -523,6 +527,8 @@ export const useServerStateStore = defineStore('serverState', () => {
         active_playlist_id: stateData.active_playlist_id ?? null,
         active_playlist_title: stateData.active_playlist_title ?? null,
         active_track_id: stateData.active_track_id ?? null,
+        // Initialize active_track_filename from active_track.filename for consistency
+        active_track_filename: stateData.active_track?.filename ?? null,
         active_track: stateData.active_track ?? null,
         position_ms: stateData.position_ms || 0,
         duration_ms: stateData.duration_ms || 0,

--- a/front/src/tests/contracts/schemas/socketio_contracts.json
+++ b/front/src/tests/contracts/schemas/socketio_contracts.json
@@ -384,12 +384,12 @@
                 "items": {"type": "integer"},
                 "description": "List of 1-based track numbers that were deleted"
               },
-              "operation": {"type": "string"},
-              "server_seq": {"type": "number", "description": "Server sequence for state synchronization"}
+              "operation": {"type": "string"}
             },
-            "required": ["playlist_id", "track_numbers", "server_seq"]
+            "required": ["playlist_id", "track_numbers"],
+            "additionalNote": "server_seq is in the envelope, not in data (envelope: true)"
           },
-          "description": "Track deletion notification. track_numbers contains 1-based positions.",
+          "description": "Track deletion notification. track_numbers contains 1-based positions. server_seq is in the envelope.",
           "frequency": "on_demand"
         },
         "state:track_added": {

--- a/front/src/tests/contracts/schemas/socketio_contracts.json
+++ b/front/src/tests/contracts/schemas/socketio_contracts.json
@@ -2,7 +2,26 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TheOpenMusicBox Socket.IO Contracts",
   "description": "Complete contract definitions for all Socket.IO events based on DDD implementation analysis",
-  "version": "4.0.0",
+  "version": "6.0.1",
+  "deprecations": {
+    "description": "Fields and events marked for removal in future versions",
+    "fields": {
+      "duration": {
+        "deprecated_in": "6.0.0",
+        "removed_in": "7.0.0",
+        "replacement": "duration_ms",
+        "reason": "Use milliseconds for precision. duration (seconds) will be removed."
+      }
+    },
+    "events": {
+      "nfc_status": {
+        "deprecated_in": "6.0.0",
+        "removed_in": "7.0.0",
+        "replacement": "nfc_association_state",
+        "reason": "nfc_association_state has more complete state enum and additional fields"
+      }
+    }
+  },
   "event_envelope_format": {
     "description": "All state events use standardized envelope format via StateEventCoordinator",
     "schema": {
@@ -14,7 +33,10 @@
         "timestamp": {"type": "number"},
         "event_id": {"type": "string"},
         "playlist_id": {"type": ["string", "null"]},
-        "track_id": {"type": ["string", "null"]}
+        "track_filename": {
+          "type": ["string", "null"],
+          "description": "Filename of the associated track (same as Track.filename)"
+        }
       },
       "required": ["event_type", "server_seq", "data", "timestamp", "event_id"]
     }
@@ -124,6 +146,17 @@
           },
           "description": "Unsubscribe from specific playlist updates"
         },
+        "leave:nfc": {
+          "direction": "client_to_server",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "assoc_id": {"type": "string"}
+            },
+            "required": ["assoc_id"]
+          },
+          "description": "Unsubscribe from NFC association session"
+        },
         "ack:join": {
           "direction": "server_to_client",
           "payload": {
@@ -131,12 +164,12 @@
             "properties": {
               "room": {"type": "string"},
               "success": {"type": "boolean"},
-              "server_seq": {"type": "number"},
+              "server_seq": {"type": "number", "description": "Current server sequence for state synchronization"},
               "playlist_seq": {"type": "number"},
               "playlist_id": {"type": "string"},
               "message": {"type": "string"}
             },
-            "required": ["room", "success"]
+            "required": ["room", "success", "server_seq"]
           },
           "description": "Room join acknowledgment"
         },
@@ -190,7 +223,10 @@
             "type": "object",
             "properties": {
               "position_ms": {"type": "integer"},
-              "track_id": {"type": ["string", "null"]},
+              "track_filename": {
+                "type": ["string", "null"],
+                "description": "Filename of the current track (same as Track.filename)"
+              },
               "is_playing": {"type": "boolean"},
               "duration_ms": {"type": ["integer", "null"]}
             },
@@ -336,7 +372,7 @@
           "description": "Playlist update notification",
           "frequency": "on_demand"
         },
-        "state:track_deleted": {
+        "state:tracks_deleted": {
           "direction": "server_to_client",
           "envelope": true,
           "data_schema": {
@@ -345,12 +381,15 @@
               "playlist_id": {"type": "string"},
               "track_numbers": {
                 "type": "array",
-                "items": {"type": "integer"}
-              }
+                "items": {"type": "integer"},
+                "description": "List of 1-based track numbers that were deleted"
+              },
+              "operation": {"type": "string"},
+              "server_seq": {"type": "number", "description": "Server sequence for state synchronization"}
             },
-            "required": ["playlist_id", "track_numbers"]
+            "required": ["playlist_id", "track_numbers", "server_seq"]
           },
-          "description": "Track deletion notification",
+          "description": "Track deletion notification. track_numbers contains 1-based positions.",
           "frequency": "on_demand"
         },
         "state:track_added": {
@@ -417,7 +456,11 @@
               "client_op_id": {"type": "string"},
               "success": {"type": "boolean", "const": false},
               "message": {"type": "string"},
-              "error_type": {"type": "string"},
+              "error_type": {
+                "type": "string",
+                "enum": ["validation_error", "not_found", "permission_denied", "conflict", "timeout", "internal_error"],
+                "description": "Categorized error type for client handling"
+              },
               "server_seq": {"type": "number"}
             },
             "required": ["client_op_id", "success", "message", "server_seq"]
@@ -499,6 +542,10 @@
       "events": {
         "nfc_status": {
           "direction": "server_to_client",
+          "deprecated": true,
+          "deprecation_note": "Use nfc_association_state instead. Will be removed in v7.0.0",
+          "x-platform": "rpi",
+          "x-note": "RPI broadcasts to room nfc:{assoc_id}. ESP32 uses nfc_association_state instead.",
           "payload": {
             "type": "object",
             "properties": {
@@ -510,10 +557,12 @@
             },
             "required": ["assoc_id", "state"]
           },
-          "description": "NFC session status updates"
+          "description": "DEPRECATED: NFC session status updates. Use nfc_association_state instead."
         },
         "nfc_association_state": {
           "direction": "server_to_client",
+          "x-platform": ["esp32", "rpi"],
+          "x-note": "ESP32 broadcasts globally to all clients. RPI also supports this for compatibility.",
           "payload": {
             "type": "object",
             "properties": {

--- a/front/src/tests/contracts/socketio/state.contract.test.ts
+++ b/front/src/tests/contracts/socketio/state.contract.test.ts
@@ -36,16 +36,17 @@ describe('Socket.IO State Events Contract Tests', () => {
 
   it('should validate state:track_position event payload structure', () => {
     /**
-     * Contract:
+     * Contract v6.0.1:
      * - Event: 'state:track_position'
-     * - Lightweight position updates (200ms interval)
-     * - Data: {position_ms: number, track_id?: string, is_playing: boolean, duration_ms?: number}
+     * - Lightweight position updates (500ms interval)
+     * - Data: {position_ms: number, track_filename?: string, is_playing: boolean, duration_ms?: number}
+     * - Note: track_filename renamed from track_id in v6.0.0
      */
     const trackPositionPayload = {
       event_type: 'state:track_position',
       data: {
         position_ms: 45200,
-        track_id: 'track-123',
+        track_filename: 'song.mp3',  // Renamed from track_id in v6.0.0
         is_playing: true,
         duration_ms: 180000
       },

--- a/front/src/types/contracts.ts
+++ b/front/src/types/contracts.ts
@@ -18,7 +18,8 @@ export interface ApiResponse<T = any> {
 export interface ApiError {
   status: 'error';
   message: string;
-  error_type: 'validation_error' | 'not_found' | 'permission_denied' | 'rate_limit_exceeded' | 'service_unavailable' | 'internal_error' | 'conflict' | 'bad_request';
+  /** Error types per contracts v6.0.1 - includes timeout for Socket.IO */
+  error_type: 'validation_error' | 'not_found' | 'permission_denied' | 'rate_limit_exceeded' | 'service_unavailable' | 'internal_error' | 'conflict' | 'bad_request' | 'timeout';
   details?: Record<string, any>;
   timestamp: number;
   request_id: string;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,12 +1,12 @@
 /**
  * Frontend Types - Central Export Point
  *
- * Uses ONLY generated types from OpenAPI Contract v4.1.0
+ * Uses ONLY generated types from OpenAPI Contract v6.0.1
  * Zero legacy code - 100% contract-driven development
  */
 
-// Import generated types from contracts v4.1.0
-import type { components } from '../../../contracts/releases/4.1.0-7dc3483/typescript/api-types';
+// Import generated types from contracts v6.0.1
+import type { components } from '../../../contracts/releases/6.0.1/typescript/api-types';
 
 // Export core data types from OpenAPI schema
 export type Track = components['schemas']['Track'];
@@ -47,7 +47,7 @@ export type PaginatedData<T> = {
   total_pages: number;
 };
 
-// Socket.IO event types
+// Socket.IO event types (v6.0.1)
 export type StateEventEnvelope<T = any> = {
   event_type: string;
   server_seq: number;
@@ -55,7 +55,8 @@ export type StateEventEnvelope<T = any> = {
   timestamp: number;
   event_id: string;
   playlist_id?: string | null;
-  track_id?: string | null;
+  /** Renamed from track_id in v6.0.0 - contains track filename */
+  track_filename?: string | null;
 };
 
 export type OperationAck = {
@@ -79,7 +80,8 @@ export type UploadStatus = 'pending' | 'uploading' | 'complete' | 'error';
 
 export type TrackProgress = {
   position_ms: number;
-  track_id?: string | null;
+  /** Renamed from track_id in v6.0.0 - contains track filename */
+  track_filename?: string | null;
   is_playing: boolean;
   duration_ms?: number | null;
 };

--- a/front/src/types/socket.ts
+++ b/front/src/types/socket.ts
@@ -59,10 +59,13 @@ export interface PlaylistStateData {
   id: string;
   title: string;
   tracks?: Array<{
-    track_number: number;  // OpenAPI v4.1.0
+    track_number: number;  // 1-based position per OpenAPI v6.0.1
     title: string;
     filename: string;
+    /** @deprecated Use duration_ms instead */
     duration?: number;
+    /** Duration in milliseconds (preferred over duration) */
+    duration_ms?: number;
   }>;
   nfc_tag_id?: string;
   server_seq?: number;
@@ -71,8 +74,13 @@ export interface PlaylistStateData {
 export interface PlayerStateData {
   is_playing: boolean;
   active_playlist_id?: string;
+  /** @deprecated Will be renamed to active_track_filename in v7.0.0 */
   active_track_id?: string;
+  /** Track number (1-based) in current playlist */
+  active_track_number?: number;
   position_ms: number;
+  /** Duration in milliseconds */
+  duration_ms?: number;
   can_prev: boolean;
   can_next: boolean;
   server_seq: number;
@@ -81,6 +89,8 @@ export interface PlayerStateData {
 export interface TrackProgressData {
   position_ms: number;
   duration_ms: number;
+  /** Track filename (renamed from track_id in v6.0.0) */
+  track_filename?: string;
   track_number?: number;
   playlist_id?: string;
 }


### PR DESCRIPTION
## Summary

Complete alignment of rpi-firmware (backend + frontend) with contracts v6.0.1. This PR consolidates all changes from the contracts migration work.

## Backend Changes

### Socket.IO Handlers
- Add `LEAVE_NFC` event type to `SocketEventType` enum
- Implement `leave:nfc` handler for NFC room unsubscription
- Add `server_seq` to `ack:join` for `join:playlist` event (v6.0.1 requirement)
- Add contract tests for `leave:nfc` and `server_seq` validation

### API Models
- Add `TIMEOUT` to `ErrorType` enum as required by Socket.IO contracts

### Event Payloads
- Rename `track_id` to `track_filename` in `state:track_position` event payload

## Frontend Changes

### TypeScript Types
- Update imports from contracts v4.1.0 to v6.0.1
- Rename `track_id` to `track_filename` in `StateEventEnvelope` and `TrackProgress`
- Add `duration_ms` to `PlaylistStateData` tracks (preferred over `duration`)
- Add `active_track_number` and `duration_ms` to `PlayerStateData`
- Add `track_filename` to `TrackProgressData`
- Add `timeout` to `ApiError.error_type` union
- Mark deprecated fields with JSDoc `@deprecated` annotations

### Socket Services
- Update event types in `socketService.ts` and `SocketService.class.ts`
- Update `serverStateStore` to handle `track_filename` field

### Contract Tests
- Update test fixtures to use `track_filename`
- Update schema references to v6.0.1

## Breaking Changes

- `track_id` field renamed to `track_filename` in `state:track_position` events
- Clients must handle `track_filename` instead of `track_id`

## Files Changed

### Backend (5 files)
- `back/app/src/common/socket_events.py` - Added `LEAVE_NFC` event type
- `back/app/src/common/response_models.py` - Added `TIMEOUT` to ErrorType enum
- `back/app/src/routes/handlers/subscription_handlers.py` - Implemented `leave:nfc`, added `server_seq`
- `back/app/src/application/services/state_event_coordinator.py` - `track_id` → `track_filename`
- `back/tests/contracts/test_socketio_subscription_contract.py` - Added contract tests

### Frontend (8 files)
- `front/src/types/index.ts` - Updated imports to v6.0.1, renamed track_id
- `front/src/types/socket.ts` - Added duration_ms, active_track_number, track_filename
- `front/src/types/contracts.ts` - Added timeout to error_type
- `front/src/services/socketService.ts` - Updated event types
- `front/src/services/SocketService.class.ts` - Updated event types
- `front/src/stores/serverStateStore.ts` - Updated to use track_filename
- `front/src/tests/contracts/schemas/socketio_contracts.json` - Updated to v6.0.1
- `front/src/tests/contracts/socketio/state.contract.test.ts` - Updated tests

## Related Issues

- Closes #136 (leave:nfc handler)
- Closes #137 (frontend types v6.0.1)
- Part of EPIC #134

## Test Results

- ✅ Backend: 122 passed, 13 skipped
- ✅ Frontend: 612 passed, 1 skipped

## Test plan

- [x] Backend unit tests pass
- [x] Backend contract tests pass
- [x] Frontend unit tests pass
- [x] Frontend contract tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)