### PR TITLE
chore(ci): Remove develop-middleware branch trigger from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, develop-middleware]
+    branches: [develop]
     types: [opened, synchronize, reopened]
 
 # Cancel in-progress runs for the same branch

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,7 +2,7 @@ name: Export Metrics
 
 on:
   push:
-    branches: [develop, develop-middleware]
+    branches: [develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Remove `develop-middleware` from CI and metrics workflow branch triggers
- The `develop-middleware` branch strategy is no longer used

## Test plan

- [ ] CI workflows still trigger correctly on PRs targeting `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)