### PR TITLE
fix/149(security): Stop tracking .env files in git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         # actions/checkout@v4.2.2
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Create .env from template
+        run: cp .env.example .env
+
       # Python 3.13 is pre-installed on self-hosted runner
       # - name: Set up Python
       #   uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: true
+          token: ${{ secrets.SUBMODULE_TOKEN }}
 
       - name: Set up Node.js
         # actions/setup-node@v4.2.0

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -33,6 +33,9 @@ jobs:
       # actions/checkout@v4.2.2
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+    - name: Create .env from template
+      run: cp back/.env.example back/.env
+
     # Python 3.13 is pre-installed on self-hosted runner
     # - name: Set up Python
     #   uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,13 @@ contract-validation-reports/
 .env.test.local
 .env.production.local
 
+# Project environment files (tracked via .env.example templates)
+back/.env
+front/.env
+front/.env.build
+front/.env.development
+front/cookies.txt
+
 # =========================
 # Logs
 # =========================

--- a/back/.env.example
+++ b/back/.env.example
@@ -1,4 +1,5 @@
 # TheOpenMusicBox Backend Configuration
+# Copy this file to .env and adjust values as needed
 # Single source of truth for all application settings
 
 #########################
@@ -26,7 +27,7 @@ UVICORN_RELOAD=false
 #########################
 
 # CORS allowed origins, separated by semicolons
-CORS_ALLOWED_ORIGINS=http://localhost:8000;http://localhost:8080;http://localhost:8081;http://127.0.0.1:8000;http://127.0.0.1:8080;http://127.0.0.1:8081;http://theopenmusicbox2.local:8000;*
+CORS_ALLOWED_ORIGINS=http://localhost:8000;http://localhost:8080;http://localhost:8081;http://127.0.0.1:8000;http://127.0.0.1:8080;http://127.0.0.1:8081;http://theopenmusicbox2.local:8000
 
 #########################
 # Storage Configuration #
@@ -86,7 +87,7 @@ MDNS_SERVICE_FRIENDLY_NAME=The Open Music Box
 # Event monitoring - Only active in DEBUG mode
 ENABLE_EVENT_MONITORING=true
 
-# Performance monitoring - Only active in DEBUG mode  
+# Performance monitoring - Only active in DEBUG mode
 ENABLE_PERFORMANCE_MONITORING=true
 
 # Maximum events to keep in trace history

--- a/front/.env.build.example
+++ b/front/.env.build.example
@@ -1,4 +1,5 @@
 # Environment configuration for TheOpenMusicBox frontend build
+# Copy this file to .env.build and adjust values as needed
 # This file is used specifically for the build process in the sync script
 VUE_APP_API_URL=http://localhost:8000
 VUE_APP_PUBLIC_PATH=/

--- a/front/.env.development
+++ b/front/.env.development
@@ -1,3 +1,0 @@
-# Environment configuration for TheOpenMusicBox frontend build
-# This file is used specifically for the build process in the sync script
-VUE_APP_API_URL=http://localhost:8000

--- a/front/.env.development.example
+++ b/front/.env.development.example
@@ -1,0 +1,3 @@
+# Environment configuration for TheOpenMusicBox frontend development
+# Copy this file to .env.development and adjust values as needed
+VUE_APP_API_URL=http://localhost:8000

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,5 +1,5 @@
 # Environment configuration for TheOpenMusicBox frontend
-# Add additional environment variables as needed
+# Copy this file to .env and adjust values as needed
 VUE_APP_API_URL=http://localhost:8000
 VUE_APP_PUBLIC_PATH=/
 VUE_APP_ASSETS_DIR=assets


### PR DESCRIPTION
## Summary
- Remove `.env` files from git tracking (`back/.env`, `front/.env`, `front/.env.build`, `front/.env.development`)
- Add `.env.example` templates for each environment file
- Update `.gitignore` to exclude `.env` files and `cookies.txt`
- Files remain on disk but are no longer committed to the repository

## Test plan
- [ ] Verify `.env.example` files contain correct template values
- [ ] Verify existing `.env` files on dev machines are unaffected
- [ ] After checkout, copy `.env.example` to `.env` and verify app starts

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)