### PR TITLE
fix(ci): Remove submodules checkout from metrics workflow

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Checkout code
         # actions/checkout@v4.2.2
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          submodules: recursive
 
       # === Backend Tests and Metrics ===
       - name: Set up Python virtual environment


### PR DESCRIPTION
## Summary
- Retire `submodules: recursive` du checkout dans `metrics.yml`
- Le workflow n'a pas besoin du submodule `contracts` pour collecter les métriques
- Le `GITHUB_TOKEN` par défaut n'a pas accès au repo privé `contracts`, causant un échec systématique

Closes #153

## Test plan
- [ ] Vérifier que le workflow Export Metrics passe sur develop après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)