### PR TITLE
fix(ci): add missing .env creation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
           submodules: recursive
           token: ${{ secrets.SUBMODULE_TOKEN }}
 
+      - name: Create .env from template
+        run: cp back/.env.example back/.env
+
       - name: Set up Python virtual environment
         run: |
           cd back


### PR DESCRIPTION
## Summary

- Adds `cp back/.env.example back/.env` step in the deploy workflow test job
- Fixes `FileNotFoundError` in conftest.py that caused the first deploy run to fail

## Related

- Follow-up to #155 / #17

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, deploy workflow triggers and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)