### PR TITLE
fix(ci): clean untracked files before deploy branch checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,7 +192,8 @@ jobs:
           COMMIT_SHA="${{ github.sha }}"
           SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
 
-          # Switch to deploy branch (clean checkout)
+          # Clean untracked files (node_modules, build artifacts) before switching branch
+          git clean -fd
           git fetch origin deploy
           git checkout deploy
 


### PR DESCRIPTION
## Summary

- Add `git clean -fd` before `git checkout deploy` to remove untracked files (node_modules, build artifacts) that block the branch switch

## Related

- Follow-up to #155 / #17

## Test plan

- [ ] CI passes
- [ ] After merge, deploy workflow succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)