### PR TITLE
fix(ci): use git clean -fdx to remove ignored files before deploy checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,8 +192,8 @@ jobs:
           COMMIT_SHA="${{ github.sha }}"
           SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
 
-          # Clean untracked files (node_modules, build artifacts) before switching branch
-          git clean -fd
+          # Clean all untracked and ignored files (node_modules, build artifacts) before switching branch
+          git clean -fdx
           git fetch origin deploy
           git checkout deploy
 


### PR DESCRIPTION
## Summary

- Change `git clean -fd` to `git clean -fdx` so ignored files (like `front/node_modules`) are also removed before switching to the deploy branch

## Related

- Follow-up to #155 / #17

## Test plan

- [ ] CI passes
- [ ] After merge, deploy workflow succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)