### PR TITLE
fix(ci): force checkout to deploy branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,10 +192,9 @@ jobs:
           COMMIT_SHA="${{ github.sha }}"
           SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
 
-          # Clean all untracked and ignored files (node_modules, build artifacts) before switching branch
-          git clean -fdx
+          # Force checkout to deploy branch (overrides node_modules and build artifacts)
           git fetch origin deploy
-          git checkout deploy
+          git checkout -f deploy
 
           # Create releases directory for this version
           mkdir -p releases/$VERSION


### PR DESCRIPTION
## Summary

- Use `git checkout -f deploy` instead of `git clean` + `git checkout deploy`
- `front/node_modules` persists as a local change that blocks normal checkout; force flag overrides it

## Related

- Follow-up to #155 / #17

## Test plan

- [ ] CI passes
- [ ] After merge, deploy workflow succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)