### PR TITLE
fix(stabilisation): AudioApplicationService broadcasts cassés

### DIFF
--- a/back/app/src/application/di/application_container.py
+++ b/back/app/src/application/di/application_container.py
@@ -20,8 +20,6 @@ from app.src.application.services.nfc_application_service import NfcApplicationS
 from app.src.application.services.upload_application_service import (
     UploadApplicationService,
 )
-from app.src.domain.audio.engine.state_manager import StateManager
-
 # Direct imports - no more dynamic imports
 from app.src.infrastructure.di.container import (
     get_container as get_infrastructure_container,
@@ -127,7 +125,6 @@ def register_application_services(container: ApplicationContainer) -> None:
         return AudioApplicationService(
             audio_domain_container=audio_domain_container,
             playlist_application_service=playlist_service,
-            state_manager=StateManager(),
         )
     container.register_factory("audio_application_service", audio_application_service_factory)
 

--- a/back/app/src/application/services/audio_application_service.py
+++ b/back/app/src/application/services/audio_application_service.py
@@ -25,13 +25,12 @@ class AudioApplicationService:
     audio use cases following DDD principles.
     """
 
-    def __init__(self, audio_domain_container, playlist_application_service, state_manager=None):
+    def __init__(self, audio_domain_container, playlist_application_service):
         """Initialize audio application service.
 
         Args:
             audio_domain_container: Domain audio container (required)
             playlist_application_service: Playlist application service (required)
-            state_manager: State management service
         """
         if audio_domain_container is None:
             raise ValueError("Audio domain container is required for application service")
@@ -39,7 +38,6 @@ class AudioApplicationService:
             raise ValueError("Playlist application service is required for audio service")
         self._audio_container = audio_domain_container
         self._playlist_service = playlist_application_service
-        self._state_manager = state_manager
 
     async def play_playlist_use_case(self, playlist_id: str) -> dict[str, Any]:
         """Use case: Start playing a playlist.
@@ -90,9 +88,6 @@ class AudioApplicationService:
             success = await audio_engine.set_playlist(playlist)
             if success:
                 logger.info(f"✅ Playing playlist via domain audio engine: {playlist_id}")
-                # Broadcast state change if state manager available
-                if self._state_manager:
-                    await self._state_manager.broadcast_playlist_started(playlist_id)
                 return {
                     "status": "success",
                     "message": "Playlist started successfully",
@@ -141,9 +136,6 @@ class AudioApplicationService:
                 }
             if success:
                 logger.info(f"✅ Playback control via domain engine: {action}")
-                # Broadcast state change if state manager available
-                if self._state_manager:
-                    await self._state_manager.broadcast_playback_changed(action)
                 return {
                     "status": "success",
                     "message": f"Playback {action} executed successfully",
@@ -206,11 +198,6 @@ class AudioApplicationService:
 
                 if success:
                     logger.info(f"✅ Volume set via domain engine: {volume}")
-
-                    # Broadcast state change if state manager available
-                    if self._state_manager:
-                        await self._state_manager.broadcast_volume_changed(volume)
-
                     return {
                         "status": "success",
                         "message": f"Volume set to {volume}",

--- a/back/tests/unit/application/services/test_audio_application_service.py
+++ b/back/tests/unit/application/services/test_audio_application_service.py
@@ -35,25 +35,11 @@ class TestAudioApplicationService:
         return AsyncMock()
 
     @pytest.fixture
-    def mock_state_manager(self):
-        """Mock state manager."""
-        return AsyncMock()
-
-    @pytest.fixture
     def audio_service(self, mock_audio_container, mock_playlist_service):
         """Create AudioApplicationService instance."""
         return AudioApplicationService(
             mock_audio_container,
             mock_playlist_service
-        )
-
-    @pytest.fixture
-    def audio_service_with_state_manager(self, mock_audio_container, mock_playlist_service, mock_state_manager):
-        """Create AudioApplicationService instance with state manager."""
-        return AudioApplicationService(
-            mock_audio_container,
-            mock_playlist_service,
-            mock_state_manager
         )
 
     # ================================================================================
@@ -68,19 +54,6 @@ class TestAudioApplicationService:
         # Assert
         assert service._audio_container == mock_audio_container
         assert service._playlist_service == mock_playlist_service
-        assert service._state_manager is None
-
-    def test_init_with_state_manager(self, mock_audio_container, mock_playlist_service, mock_state_manager):
-        """Test initialization with optional state manager."""
-        # Act
-        service = AudioApplicationService(
-            mock_audio_container,
-            mock_playlist_service,
-            mock_state_manager
-        )
-
-        # Assert
-        assert service._state_manager == mock_state_manager
 
     def test_init_requires_audio_container(self, mock_playlist_service):
         """Test initialization fails without audio container."""
@@ -131,28 +104,6 @@ class TestAudioApplicationService:
         assert result["playlist_id"] == playlist_id
         assert result["track_count"] == 1
         mock_audio_container.audio_engine.set_playlist.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_play_playlist_broadcasts_state(self, audio_service_with_state_manager, mock_playlist_service, mock_audio_container, mock_state_manager):
-        """Test playlist playback broadcasts state change."""
-        # Arrange
-        playlist_id = "playlist-123"
-        mock_playlist_service.get_playlist_use_case.return_value = {
-            "status": "success",
-            "playlist": {
-                "id": playlist_id,
-                "title": "Test Playlist",
-                "tracks": [{"track_number": 1, "title": "Song 1", "filename": "song1.mp3"}]
-            }
-        }
-        mock_audio_container.audio_engine.set_playlist.return_value = True
-
-        # Act
-        result = await audio_service_with_state_manager.play_playlist_use_case(playlist_id)
-
-        # Assert
-        assert result["status"] == "success"
-        mock_state_manager.broadcast_playlist_started.assert_called_once_with(playlist_id)
 
     @pytest.mark.asyncio
     async def test_play_playlist_not_found(self, audio_service, mock_playlist_service):
@@ -338,19 +289,6 @@ class TestAudioApplicationService:
         assert result["error_type"] == "validation_error"
 
     @pytest.mark.asyncio
-    async def test_control_playback_broadcasts_state(self, audio_service_with_state_manager, mock_audio_container, mock_state_manager):
-        """Test playback control broadcasts state change."""
-        # Arrange
-        mock_audio_container.audio_engine.pause.return_value = True
-
-        # Act
-        result = await audio_service_with_state_manager.control_playback_use_case("pause")
-
-        # Assert
-        assert result["status"] == "success"
-        mock_state_manager.broadcast_playback_changed.assert_called_once_with("pause")
-
-    @pytest.mark.asyncio
     async def test_control_playback_engine_failure(self, audio_service, mock_audio_container):
         """Test playback control when engine fails."""
         # Arrange
@@ -435,20 +373,6 @@ class TestAudioApplicationService:
         assert result["status"] == "success"
         assert result["volume"] == volume
         mock_audio_container.audio_engine.set_volume.assert_called_once_with(volume)
-
-    @pytest.mark.asyncio
-    async def test_set_volume_broadcasts_state(self, audio_service_with_state_manager, mock_audio_container, mock_state_manager):
-        """Test volume setting broadcasts state change."""
-        # Arrange
-        volume = 50
-        mock_audio_container.audio_engine.set_volume.return_value = True
-
-        # Act
-        result = await audio_service_with_state_manager.set_volume_use_case(volume)
-
-        # Assert
-        assert result["status"] == "success"
-        mock_state_manager.broadcast_volume_changed.assert_called_once_with(volume)
 
     @pytest.mark.asyncio
     async def test_set_volume_min_value(self, audio_service, mock_audio_container):


### PR DESCRIPTION
## Summary
- Remove 3 broken broadcast calls (`broadcast_playlist_started`, `broadcast_playback_changed`, `broadcast_volume_changed`) that called non-existent methods on the injected StateManager
- Remove `state_manager` parameter from AudioApplicationService constructor
- Clean up unused StateManager import from application_container.py
- Remove 4 obsolete test methods that tested the broken broadcasts

Closes #163
Part of epic #161

## Test plan
- [x] All 27 remaining AudioApplicationService tests pass
- [x] No regression on full backend test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)