### PR TITLE
fix(stabilisation): move_track_between_playlists sans broadcast

### DIFF
--- a/back/app/src/api/endpoints/playlist/playlist_track_api.py
+++ b/back/app/src/api/endpoints/playlist/playlist_track_api.py
@@ -170,6 +170,14 @@ class PlaylistTrackAPI(BaseAPIRoutes):
                 )
 
                 if result.get("status") == "success":
+                    # Broadcast state change for both affected playlists
+                    await self._broadcasting_service.broadcast_playlist_updated(
+                        source_playlist_id, {"operation": "move_track", "role": "source"}
+                    )
+                    await self._broadcasting_service.broadcast_playlist_updated(
+                        target_playlist_id, {"operation": "move_track", "role": "target"}
+                    )
+
                     return UnifiedResponseService.success(
                         message=result.get("message", "Track moved successfully"),
                         data={"client_op_id": client_op_id or ""}


### PR DESCRIPTION
## Summary
- Add `broadcast_playlist_updated()` calls for both source and target playlists after successful track move
- Follows the same pattern as `reorder_tracks` and `delete_tracks` which already broadcast

Closes #167
Part of epic #161

## Test plan
- [x] Broadcast called for both source and target playlists
- [x] Pattern matches existing broadcast calls in same file

🤖 Generated with [Claude Code](https://claude.com/claude-code)