### PR TITLE
fix(stabilisation): Architecture tests avec angles morts

### DIFF
--- a/back/tests/architecture/helpers.py
+++ b/back/tests/architecture/helpers.py
@@ -127,21 +127,26 @@ def get_layer_from_module(module_path: str) -> str:
 
     # Extract layer from path structure - check both patterns
     # For paths like "domain.audio.backends" or "/domain/"
-    if '/domain/' in normalized_path or normalized_path.startswith('domain/'):
+    # Each check handles three cases:
+    #   1. Layer appears mid-path: '/domain/' in path
+    #   2. Path starts with layer: path.startswith('domain/')
+    #   3. Path ends with layer (e.g. 'app/src/config' normalized from 'app.src.config'):
+    #      path.endswith('/domain') or path == 'domain'
+    if '/domain/' in normalized_path or normalized_path.startswith('domain/') or normalized_path.endswith('/domain') or normalized_path == 'domain':
         return 'domain'
-    elif '/application/' in normalized_path or normalized_path.startswith('application/'):
+    elif '/application/' in normalized_path or normalized_path.startswith('application/') or normalized_path.endswith('/application') or normalized_path == 'application':
         return 'application'
-    elif '/infrastructure/' in normalized_path or normalized_path.startswith('infrastructure/'):
+    elif '/infrastructure/' in normalized_path or normalized_path.startswith('infrastructure/') or normalized_path.endswith('/infrastructure') or normalized_path == 'infrastructure':
         return 'infrastructure'
-    elif '/routes/' in normalized_path or '/api/' in normalized_path or normalized_path.startswith('routes/') or normalized_path.startswith('api/'):
+    elif '/routes/' in normalized_path or '/api/' in normalized_path or normalized_path.startswith('routes/') or normalized_path.startswith('api/') or normalized_path.endswith('/routes') or normalized_path.endswith('/api') or normalized_path == 'routes' or normalized_path == 'api':
         return 'ui'
-    elif '/controllers/' in normalized_path or normalized_path.startswith('controllers/'):
+    elif '/controllers/' in normalized_path or normalized_path.startswith('controllers/') or normalized_path.endswith('/controllers') or normalized_path == 'controllers':
         return 'controllers'
-    elif '/services/' in normalized_path or normalized_path.startswith('services/'):
+    elif '/services/' in normalized_path or normalized_path.startswith('services/') or normalized_path.endswith('/services') or normalized_path == 'services':
         return 'services'
-    elif '/config/' in normalized_path or normalized_path.startswith('config/'):
+    elif '/config/' in normalized_path or normalized_path.startswith('config/') or normalized_path.endswith('/config') or normalized_path == 'config':
         return 'config'
-    elif '/monitoring/' in normalized_path or normalized_path.startswith('monitoring/'):
+    elif '/monitoring/' in normalized_path or normalized_path.startswith('monitoring/') or normalized_path.endswith('/monitoring') or normalized_path == 'monitoring':
         return 'monitoring'
     else:
         return 'unknown'

--- a/back/tests/architecture/test_domain_purity.py
+++ b/back/tests/architecture/test_domain_purity.py
@@ -207,12 +207,22 @@ class TestDomainLayerPurity:
             "json",  # For serialization
             "re",    # For validation
             "time",  # For timing
-            "os",    # Basic OS operations
             "sys",   # System info
             "app.src.domain",  # Own domain modules
             "app.src.monitoring",  # Logging is acceptable
             "pygame",  # Audio library for domain audio backends
             "mutagen"  # Audio metadata library for domain audio backends
+        ]
+
+        # Explicitly forbidden standard library modules in domain layer.
+        # These are caught by the stdlib fallback check, so we must deny them explicitly.
+        # Domain code should not perform filesystem or OS-level operations directly.
+        forbidden_stdlib = [
+            "os",      # Filesystem/OS operations belong in infrastructure
+            "shutil",  # File copy/move operations belong in infrastructure
+            "subprocess",  # Process management belongs in infrastructure
+            "socket",  # Network operations belong in infrastructure
+            "glob",    # Filesystem globbing belongs in infrastructure
         ]
 
         for file_path in domain_files:
@@ -225,6 +235,17 @@ class TestDomainLayerPurity:
 
                 # Skip imports that are None (relative imports without module)
                 if import_line is None:
+                    continue
+
+                # Check if import is explicitly forbidden (even if stdlib)
+                is_forbidden = False
+                for forbidden in forbidden_stdlib:
+                    if import_line == forbidden or import_line.startswith(forbidden + "."):
+                        is_forbidden = True
+                        break
+
+                if is_forbidden:
+                    violations.append(f"🚨 Domain → Forbidden stdlib: {file_path} imports {import_line}")
                     continue
 
                 # Check if import is allowed
@@ -272,10 +293,19 @@ class TestDomainLayerPurity:
                 if not is_allowed:
                     violations.append(f"🚨 Domain → External Library: {file_path} imports {import_line}")
 
-        # Only fail if there are significant violations (more than reasonable internal domain imports)
-        # Most violations we're seeing are internal domain module references that the parser
-        # is treating as external. This allows for reasonable internal domain structure.
-        if len(violations) > 80:
+        # Threshold for maximum tolerated violations.
+        # Known violations (as of 2026-04-10): 63 total
+        #   - 56 are false positives from internal domain relative imports
+        #     (e.g., __init__.py re-exports like 'audio_events', 'entities.nfc_tag')
+        #     that the AST parser treats as external modules.
+        #   - 7 are real forbidden stdlib imports pending infrastructure leak refactoring:
+        #     * factory.py imports os
+        #     * wm8960_audio_backend.py imports os, subprocess
+        #     * macos_audio_backend.py imports os
+        #     * track_service.py imports os
+        #     * playlist_service.py imports shutil (x2)
+        # Threshold set to current known count (63) + 5 margin for minor churn.
+        if len(violations) > 68:
             pytest.fail(f"""
             ❌ DOMAIN LAYER EXTERNAL DEPENDENCIES!
 


### PR DESCRIPTION
## Summary
- Fix `get_layer_from_module()` in helpers.py to detect bare paths like `app/src/config` (was returning 'unknown')
- Remove `os` from allowed_libraries in domain purity test
- Add explicit `forbidden_stdlib` list (os, shutil, subprocess, socket, glob) checked before stdlib fallback
- Lower violation threshold from >80 to >68 with documented known violations
- Now surfaces 7 real forbidden stdlib violations + 2 dependency direction violations that were previously invisible

Closes #170
Part of epic #161

## Test plan
- [x] `get_layer_from_module('config')` now returns 'config' instead of 'unknown'
- [x] Architecture tests pass with new stricter settings
- [x] Known violations documented in threshold comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)