### PR TITLE
chore(stabilisation): Scripts frontend non intégrés dans package.json

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -16,6 +16,8 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:integration": "vitest run src/tests/integration",
     "test:contracts": "vitest run src/tests/contracts",
+    "test:contracts:validate": "node test_validator.js",
+    "validate:config": "node validate-config.js",
     "fix:unit-tests": "node scripts/repair-unit-tests.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `validate:config` script (runs validate-config.js)
- Add `test:contracts:validate` script (runs test_validator.js)
- Both scripts existed at front/ root but were not discoverable via npm run

Closes #171
Part of epic #161

## Test plan
- [x] `npm run validate:config` runs the webpack config validator
- [x] Scripts placed logically near existing test/validation scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)