### PR TITLE
fix(monitoring): aligner deploy.yml + release.yml sur # TYPE/# HELP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ permissions:
   contents: read
 
 env:
-  PUSHGATEWAY_URL: http://host.docker.internal:9091
   USE_MOCK_HARDWARE: "true"
   ENVIRONMENT: test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -237,6 +237,10 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           DEPLOY_SUCCESS=${{ job.status == 'success' && 1 || 0 }}
           cat <<EOF | curl --data-binary @- http://host.docker.internal:9091/metrics/job/deploy/instance/raspberrypi-firmware || true
+          # HELP deploy_success Whether the latest deployment succeeded (1=success, 0=failure)
+          # TYPE deploy_success gauge
           deploy_success{repo="raspberrypi-firmware",version="v${VERSION}"} ${DEPLOY_SUCCESS}
+          # HELP deploy_timestamp Unix timestamp of the latest deployment
+          # TYPE deploy_timestamp gauge
           deploy_timestamp{repo="raspberrypi-firmware",version="v${VERSION}"} $(date +%s)
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,10 @@ jobs:
         run: |
           RELEASE_SUCCESS=${{ job.status == 'success' && 1 || 0 }}
           cat <<EOF | curl --data-binary @- http://host.docker.internal:9091/metrics/job/release/instance/raspberrypi-firmware || true
+          # HELP release_success Whether the latest release succeeded (1=success, 0=failure)
+          # TYPE release_success gauge
           release_success{repo="raspberrypi-firmware",version="v${{ inputs.version }}"} ${RELEASE_SUCCESS}
+          # HELP release_timestamp Unix timestamp of the latest release
+          # TYPE release_timestamp gauge
           release_timestamp{repo="raspberrypi-firmware",version="v${{ inputs.version }}"} $(date +%s)
           EOF


### PR DESCRIPTION
Closes #184
Refs The-Open-Music-Box/infrastructure#9

## Summary

Suite à #183 qui a fixé `metrics.yml` (17 métriques avec # TYPE), cette PR ferme les 2 dernières fuites :

- `deploy.yml` : ajoute # HELP/# TYPE pour `deploy_success`, `deploy_timestamp`
- `release.yml` : idem pour `release_success`, `release_timestamp`
- `ci.yml` : retire la variable env `PUSHGATEWAY_URL` inutilisée (vestige)

## Pourquoi

Sans cette PR, chaque deploy/release rpi-firmware peut re-verrouiller le registre pushgateway en untyped — refaisant ressurgir l'incident "No Data" sur middleware/HIL/etc. dans Grafana.

Même reasoning que #183 : ce repo est deprecated (seul ESP32 actif) MAIS ses pushes restent dans `pushgateway.dat` et continuent de polluer.

## Test plan

- [ ] CI verte
- [ ] Aucun bloc `cat ... curl ... :9091` sans # TYPE/# HELP restant : `grep -r '9091' .github/workflows/ | grep -v -B1 'TYPE'` → vide

🤖 Generated with [Claude Code](https://claude.com/claude-code)