### PR TITLE
chore(ci): disable Export Metrics workflow on deprecated RPI firmware

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,8 +1,22 @@
-name: Export Metrics
+# DEPRECATED: This workflow is disabled because raspberrypi-firmware is the only
+# public repo in the org. GitHub Actions blocks public-workflow → private-action
+# resolution for security reasons (anti-fork-exfiltration). The composite actions
+# this workflow depends on live in the private The-Open-Music-Box/infrastructure
+# repo, so the workflow fails immediately with "Unable to resolve action".
+#
+# The RPI firmware is also deprecated (only ESP32 firmware is actively developed),
+# so the simplest fix is to stop pushing metrics for this repo entirely.
+#
+# Refs:
+# - The-Open-Music-Box/raspberrypi-firmware#187 (this change)
+# - The-Open-Music-Box/infrastructure#46 (root cause + options)
+#
+# To re-enable: trigger manually via Actions UI (workflow_dispatch) and ensure
+# either infrastructure is made public OR copy the composites into this repo.
+name: Export Metrics (disabled)
 
 on:
-  push:
-    branches: [develop]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Disable `.github/workflows/metrics.yml` by switching trigger from `on:push` to `on:workflow_dispatch` (manual-only)
- Add header comment explaining why and how to re-enable
- Rename workflow to `Export Metrics (disabled)` so it's clear in the Actions UI

## Why

`raspberrypi-firmware` is the only public repo in the org. GitHub Actions blocks public-workflow → private-action resolution for security reasons (anti-fork-exfiltration). The composite actions this workflow depends on live in the private `The-Open-Music-Box/infrastructure` repo, so the workflow fails immediately with `Unable to resolve action 'the-open-music-box/infrastructure', not found`.

Combined with the fact that RPI firmware is deprecated (only ESP32 firmware is actively developed), the simplest fix is to stop pushing metrics for this repo entirely.

## Effect on Grafana

The dashboard `04-rpi-firmware` will be removed and the 3 RPI panels in `00-general-summary` will be removed (handled outside this PR in the local Grafana provisioning).

## Test plan

- [x] CI runs of other workflows (`Deploy`, `Contract Validation`) still trigger normally on push (unchanged in this PR)
- [ ] After merge: verify no new `Export Metrics` run is queued on the next `develop` push
- [ ] Verify the workflow still shows up in Actions UI with the "(disabled)" suffix and is launchable via `workflow_dispatch`

Closes #187
Refs The-Open-Music-Box/infrastructure#46

🤖 Generated with [Claude Code](https://claude.com/claude-code)