### PR TITLE
chore(ci): disable auto-triggers on deprecated repo workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [develop]
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  # Repo deprecated: auto-triggers disabled (rpi-firmware#189). ESP32 firmware
+  # is the active product. Re-enable only if RPI development resumes.
 
 # Cancel in-progress runs for the same branch
 concurrency:

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -1,13 +1,7 @@
 name: Contract Validation
 
 on:
-  push:
-    branches: [ develop, feat/*, fix/* ]
-  pull_request:
-    branches: [ develop ]
-  schedule:
-    # Run daily at 2 AM UTC to catch any drift
-    - cron: '0 2 * * *'
+  # Repo deprecated: auto-triggers disabled (rpi-firmware#189). Manual only.
   workflow_dispatch:  # Allow manual triggering from GitHub UI
 
 # Minimal permissions for security hardening

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,9 +1,7 @@
 name: Dependency Check
 
 on:
-  schedule:
-    # Run weekly on Monday at 9 AM UTC
-    - cron: '0 9 * * 1'
+  # Repo deprecated: weekly schedule disabled (rpi-firmware#189). Manual only.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,7 @@
 name: Deploy
 
 on:
-  push:
-    branches: [develop]
+  # Repo deprecated: auto push trigger disabled (rpi-firmware#189). Manual only.
   workflow_dispatch:
     inputs:
       version_override:


### PR DESCRIPTION
## Contexte

Suite à #188 qui a déjà passé `metrics.yml` et `release.yml` en `workflow_dispatch` uniquement, on aligne les 4 workflows restants sur le même modèle :

- `ci.yml` (était : `pull_request` → develop)
- `deploy.yml` (était : `push` → develop)
- `contract-validation.yml` (était : `push` + `pull_request` + `schedule` daily)
- `dependency-check.yml` (était : `schedule` weekly)

## Pourquoi

`rpi-firmware` est officiellement déprécié au profit de `esp32-firmware`. Mais ces workflows continuaient à se déclencher automatiquement et à pousser des métriques vers le Pushgateway de la stack monitoring locale (constat aujourd'hui : `deploy_success{repo="raspberrypi-firmware",version="v0.5.4-dev"}` poussé à 14:10 UTC).

Cela polluait Grafana : les séries `raspberrypi-firmware` apparaissaient dans les panels "all-repos" du dashboard CI/CD Summary (`Coverage Trend`, `Lint Issues`, `Security Issues`, `Type Errors`, `Outdated Deps`, `Test Results`, `Last Build Time`).

## Changes

Pour chaque workflow :
- Bloc `on:` réduit à `workflow_dispatch:` uniquement
- Commentaire explicatif référençant #189

## Trade-off

- Préserve l'historique CI (fichiers présents)
- Permet une relance manuelle exceptionnelle
- Stoppe tout run automatique → plus de pollution du monitoring local

## Acceptation

- [ ] CI verte (manual runs uniquement)
- [ ] `gh workflow list -R The-Open-Music-Box/raspberrypi-firmware` montre tous les workflows en "manual"
- [ ] Aucun run automatique pendant 7 jours

Closes #189