### PR TITLE
chore(ci): la CI doit se déclencher sur toute PR (retrait du filtre branches)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop]
     types: [opened, synchronize, reopened]
 
 # Cancel in-progress runs for the same branch

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ develop, feat/*, fix/* ]
   pull_request:
-    branches: [ develop ]
   schedule:
     # Run daily at 2 AM UTC to catch any drift
     - cron: '0 2 * * *'


### PR DESCRIPTION
Closes #193

## Changement

Retrait du filtre `branches:` sous `pull_request:` dans deux workflows :
- `.github/workflows/ci.yml` — suppression de `branches: [develop]`
- `.github/workflows/contract-validation.yml` — suppression de `branches: [ develop ]`

## Pourquoi

La CI ne se déclenchait que sur les PR ciblant `develop`. Les PR empilées d'un EPIC, qui ciblent une branche intermédiaire (`epic/*` ou sous-branche), ne recevaient donc aucun run CI. Après ce changement, la CI se déclenche sur toute PR quelle que soit sa branche cible.

`types:`, `paths:`, `push:`, `schedule:` et `workflow_dispatch:` sont conservés inchangés. Diff total : 2 lignes supprimées.

Référence : `infrastructure/docs/ENVIRONMENTS-CI-ALIGNMENT.md` §6.1 et §12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)