### PR TITLE
chore(legal): switch license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,21 @@
-Copyright (c) 2025 Jonathan Piette
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to use, copy, modify, merge, publish, and distribute copies of the Software, subject to the following conditions:
+Copyright (c) 2026 Jonathan Piette
 
-1. **Non-Commercial Use:**
-   - The Software may only be used, copied, modified, and distributed for non-commercial purposes.
-   - "Non-commercial" means not primarily intended for or directed towards commercial advantage or monetary compensation by anyone other than the original author.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-2. **Commercial Use Reserved:**
-   - Commercial use, including but not limited to selling, offering paid services, or distributing as part of a paid product or service, is reserved exclusively to the original author, Jonathan Piette.
-   - If you wish to monetize, sell, or otherwise use the Software for commercial purposes, you must obtain a commercial license from the copyright holder.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-3. **Contributions:**
-   - Contributions are welcome from anyone via pull requests or issues.
-   - By contributing, you agree that your contributions may be incorporated into the Software and distributed under this license.
-
-4. **No Warranty:**
-   - The Software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Software or the use or other dealings in the Software.
-
-For commercial licensing inquiries, contact: Jonathan Piette
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > Cette version Raspberry Pi **reste fonctionnelle** et continuera de bénéficier d'un **support de maintenance**, mais elle ne fait plus l'objet de nouvelles fonctionnalités ou de mises à jour prioritaires.
 > Suivez l'évolution du projet sur notre [page Facebook](https://www.facebook.com/theopenmusicbox).
 
-[![License](https://img.shields.io/badge/License-Custom-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.9+-green.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-latest-teal.svg)](https://fastapi.tiangolo.com/)
 [![Vue.js](https://img.shields.io/badge/Vue.js-3.x-brightgreen.svg)](https://vuejs.org/)
@@ -1045,14 +1045,7 @@ Ouvrez une [issue](https://github.com/yourusername/tomb-rpi/issues) en incluant:
 
 ## 📄 License
 
-Ce projet est open source avec les conditions suivantes:
-
-- ✅ **Usage libre**: Utilisation, copie, modification, distribution pour usage **non commercial**
-- ✅ **Contributions**: Ouvertes à tous via pull requests et issues
-- ⚠️ **Usage commercial réservé**: La monétisation (vente, services payants, intégration dans produits payants) est **réservée exclusivement à l'auteur original (Jonathan Piette)**
-- 💼 **Licence commerciale**: Contactez l'auteur pour options de licence commerciale
-
-Voir le fichier [LICENSE](LICENSE) pour plus de détails.
+Ce projet est distribué sous licence MIT — voir [LICENSE](LICENSE).
 
 ---
 


### PR DESCRIPTION
## Summary

rpi-firmware is the only open-source repo in TheOpenMusicBox project. This switches its license from the previous custom non-commercial license to the standard **MIT License**.

## Changes

- **`LICENSE`**: replaced entirely with the standard MIT License text (Copyright (c) 2026 Jonathan Piette).
- **`README.md`**:
  - Badge `License-Custom` -> `License-MIT` (shields.io, green), linking to `LICENSE`.
  - Replaced the detailed non-commercial license section (free non-commercial use / commercial use reserved / commercial licensing contact) with a short mention: « Ce projet est distribué sous licence MIT — voir [LICENSE](LICENSE). »
  - Generic "open source" mentions left untouched (now correct under MIT).

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)